### PR TITLE
Fix maven-shade-plugin error during compileation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2125,6 +2125,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
+          <forceCreation>true</forceCreation>
           <archive>
             <index>true</index>
             <manifestEntries>


### PR DESCRIPTION
Sometime (not always) maven-shade-plugin throws error like "Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.1.0:shade (default) on project: Error creating shaded jar: duplicate entry"

This commit forces rebuilding JARs from scratch and fixes these errors.