### PR TITLE
CORSService: Extract Request Header Enumerations To Variable

### DIFF
--- a/openam-rest/src/main/java/org/forgerock/openam/cors/CORSService.java
+++ b/openam-rest/src/main/java/org/forgerock/openam/cors/CORSService.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.Enumeration;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -182,9 +183,11 @@ public class CORSService {
      */
     private boolean handleActualRequestFlow(final HttpServletRequest req, final HttpServletResponse res) {
 
-        if (req.getHeaderNames() != null) {
-            while (req.getHeaderNames().hasMoreElements()) {
-                String header = req.getHeaderNames().nextElement();
+        Enumeration<String> headerNames = req.getHeaderNames();
+
+        if (headerNames != null) {
+            while (headerNames.hasMoreElements()) {
+                String header = headerNames.nextElement();
                 if (!acceptedHeaders.contains(header.toLowerCase()) && !simpleHeaders.contains(header.toLowerCase())) {
                     DEBUG.warning("CORS Fail - Headers do not match allowed headers.");
                     return false;


### PR DESCRIPTION
When `request.getHeaderNames()` is called, a new Enumeration object is created every time, thus when the `request.getHeaderNames().nextElement()` is called it is always pointing at the first header (of the new enumeration!) creating effectively an infinite loop, if the first header is allowed by policy.

I must add that there are [comments on Jira issue OPENAM-9606](https://bugster.forgerock.org/jira/browse/OPENAM-9606) pointing at this matter. The latter comment is indicating that the bug has been fixed. But to my experience, as of this writing, it still exists and it should; considering the above logic.

I just extracted a variable before looping over the Enumeration and it seems to have solved the problem.