### PR TITLE
Radius extension to enable parsing of packet from auth module

### DIFF
--- a/openam-authentication/openam-auth-radius/src/main/java/com/sun/identity/authentication/modules/radius/client/RadiusConn.java
+++ b/openam-authentication/openam-auth-radius/src/main/java/com/sun/identity/authentication/modules/radius/client/RadiusConn.java
@@ -192,12 +192,13 @@ public class RadiusConn {
      *
      * @param name     the username.
      * @param password the password.
+     * @return the response packet.
      * @throws IOException              if there is a problem.
      * @throws NoSuchAlgorithmException if there is a problem.
      * @throws RejectException          if there is a problem.
      * @throws ChallengeException       if there is a problem.
      */
-    public void authenticate(String name, String password)
+    public Packet authenticate(String name, String password)
             throws IOException, NoSuchAlgorithmException,
             RejectException, ChallengeException {
         AccessRequest req = createAccessRequest();
@@ -206,7 +207,7 @@ public class RadiusConn {
                 secret, password));
         req.addAttribute(new NASIPAddressAttribute(InetAddress.getLocalHost()));
         req.addAttribute(new NASPortAttribute(socket.getLocalPort()));
-        sendPacket(req);
+        return sendPacket(req);
     }
 
     /**
@@ -215,12 +216,13 @@ public class RadiusConn {
      * @param name     the username.
      * @param password the password.
      * @param ce       the challenge exception providing access to the original challenge response.
+     * @return the response packet.
      * @throws IOException              if there is a problem.
      * @throws NoSuchAlgorithmException if there is a problem.
      * @throws RejectException          if there is a problem.
      * @throws ChallengeException       if there is a problem.
      */
-    public void replyChallenge(String name, String password,
+    public Packet replyChallenge(String name, String password,
                                ChallengeException ce) throws IOException, NoSuchAlgorithmException,
             RejectException, ChallengeException {
         StateAttribute state = (StateAttribute)
@@ -238,18 +240,19 @@ public class RadiusConn {
         req.addAttribute(new NASIPAddressAttribute(InetAddress.getLocalHost()));
         req.addAttribute(new NASPortAttribute(socket.getLocalPort()));
 
-        sendPacket(req);
+        return sendPacket(req);
     }
 
     /**
      * Finds an available server and then sends a packet to that servers.
      *
      * @param packet the packet.
+     * @return the response packet.
      * @throws IOException        if there is a problem.
      * @throws RejectException    if there is a problem.
      * @throws ChallengeException if there is a problem.
      */
-    private void sendPacket(Packet packet) throws IOException,
+    private Packet sendPacket(Packet packet) throws IOException,
             RejectException, ChallengeException {
         Packet res = null;
         RADIUSServer server = null;
@@ -286,6 +289,7 @@ public class RadiusConn {
                 }
             }
         }
+        return res;
     }
 
     /**


### PR DESCRIPTION
This PR will enable the openam-auth-radius module to be extended and do additional parsing and validation of the radius response packet (namely Access-Accept packet).

The changes are introducing a new protected method 'readAttributesFromResponsePacket(Packet response)' that is called after successful authentication against the RADIUS server.

The method by default is a no-op.

In an extension class the developer can override the method and either read and store attributes or throw an AuthLoginException if login failure should result from additional parsing.

