### PR TITLE
Fix Wrong link for OAuth 2.0 in Realm > Applications menu #174 issue

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/utils/RedirectToLegacyConsole.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/utils/RedirectToLegacyConsole.js
@@ -85,7 +85,7 @@ define([
 
     obj.agents = {
         java       : agentsRedirector(181),
-        oauth20    : agentsRedirector(183),
+        oauth20    : agentsRedirector(186),
         web        : agentsRedirector(180),
         redirectToTab (tabIndex, realm) {
             obj.getJATOPageSession(realm).done((session) => {


### PR DESCRIPTION
Fix Wrong link for OAuth 2.0 in Realm > Applications menu #174 issue