### PR TITLE
Fix #198: nonce is not returned in the id_token when using stateless tokens and request_type=code

### DIFF
--- a/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/StatelessTokenStore.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/StatelessTokenStore.java
@@ -20,6 +20,7 @@ import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.openam.oauth2.OAuth2Constants.Bearer.BEARER;
 import static org.forgerock.openam.oauth2.OAuth2Constants.CoreTokenParams.*;
 import static org.forgerock.openam.oauth2.OAuth2Constants.Custom.CLAIMS;
+import static org.forgerock.openam.oauth2.OAuth2Constants.Custom.NONCE;
 import static org.forgerock.openam.oauth2.OAuth2Constants.JWTTokenParams.ACR;
 import static org.forgerock.openam.oauth2.OAuth2Constants.Params.EXPIRES_IN;
 import static org.forgerock.openam.oauth2.OAuth2Constants.Params.GRANT_TYPE;
@@ -187,6 +188,7 @@ public class StatelessTokenStore implements TokenStore {
                 .claim(SCOPE, scope)
                 .claim(CLAIMS, claims)
                 .claim(REALM, realm)
+                .claim(NONCE, nonce)
                 .claim(TOKEN_NAME, OAUTH_ACCESS_TOKEN)
                 .claim(OAUTH_TOKEN_TYPE, BEARER)
                 .claim(EXPIRES_IN, expiresIn.getMillis())


### PR DESCRIPTION
If the OAuth2 provider had the "Use Stateless Access & Refresh Tokens" option activated and the client had triggered a "request_type=code" authentication, the nonce value would get lost. According to the OIDC specs, if the client supplied a nonce value, it should be returned inside the id_token.

The error was detected and tested using an ASP.net Core 3 Identity client application.