### PR TITLE
Fix #204 The OIDC device flow RFC says the parameter should be called verification_uri

### DIFF
--- a/openam-core/src/main/java/org/forgerock/openam/oauth2/OAuth2Constants.java
+++ b/openam-core/src/main/java/org/forgerock/openam/oauth2/OAuth2Constants.java
@@ -808,7 +808,7 @@ public class OAuth2Constants {
     public static class DeviceCode {
         public static final String DEVICE_CODE = "device_code";
         public static final String USER_CODE = "user_code";
-        public static final String VERIFICATION_URL = "verification_url";
+        public static final String VERIFICATION_URI = "verification_uri";
         public static final String INTERVAL = "interval";
     }
 

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/restlet/DeviceCodeResource.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/restlet/DeviceCodeResource.java
@@ -133,7 +133,7 @@ public class DeviceCodeResource extends ServerResource {
                 final String realm = request.getParameter(OAuth2Constants.Custom.REALM);
                 verificationUrl = baseURLProviderFactory.get(realm).getRootURL(servletRequest) + "/oauth2/device/user";
             }
-            result.put(VERIFICATION_URL, verificationUrl);
+            result.put(VERIFICATION_URI, verificationUrl);
 
             return jacksonRepresentationFactory.create(result);
         } catch (OAuth2Exception e) {


### PR DESCRIPTION
The OIDC Device Flow RFC (https://tools.ietf.org/html/rfc8628, paragraph 3.2) says that the `/device/code` endpoint should return a value called `verification_uri` which represents the URI to visit in a browser in order to allow device authentication. In the current OpenAM sources, this parameter is called `verification_url`.