### PR TITLE
Fix #206: Use the device code grant type as defined in RFC8628

### DIFF
--- a/openam-core/src/main/java/org/forgerock/openam/oauth2/OAuth2Constants.java
+++ b/openam-core/src/main/java/org/forgerock/openam/oauth2/OAuth2Constants.java
@@ -316,7 +316,7 @@ public class OAuth2Constants {
 
         public static final String JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer";
 
-        public static final String DEVICE_CODE = "http://oauth.net/grant_type/device/1.0";
+        public static final String DEVICE_CODE = "urn:ietf:params:oauth:grant-type:device_code";
     }
 
     /**

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/DeviceCodeGrantTypeHandler.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/DeviceCodeGrantTypeHandler.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.oauth2.core;
 
-import static org.forgerock.openam.oauth2.OAuth2Constants.Params.CODE;
+import static org.forgerock.openam.oauth2.OAuth2Constants.DeviceCode.DEVICE_CODE;
 import static org.forgerock.openam.oauth2.OAuth2Constants.Params.REALM;
 import static org.forgerock.openam.utils.StringUtils.isEmpty;
 import static org.forgerock.openam.utils.Time.currentTimeMillis;
@@ -76,7 +76,7 @@ public class DeviceCodeGrantTypeHandler extends GrantTypeHandler {
             InvalidScopeException, NotFoundException, InvalidClientException, AuthorizationDeclinedException,
             ExpiredTokenException, BadRequestException, AuthorizationPendingException {
 
-        final String code = request.getParameter(CODE);
+        final String code = request.getParameter(DEVICE_CODE);
 
         if (isEmpty(code)) {
             throw new BadRequestException("code is a required parameter");


### PR DESCRIPTION
The OIDC Device Flow RFC (https://tools.ietf.org/html/rfc8628#section-3.4) says that the token endpoint must receive the constant value `urn:ietf:params:oauth:grant-type:device_code` as the value for the `grant_type` parameter, and a `device_code` value obtained by the previous call to the `/device/code` endpoint. The current sources use a different hardcoded value for the `grant_type` parameter (`http://oauth.net/grant_type/device/1.0`) - and they read the device code parameter by accessing the `code` parameter instead of the `device_code` prescribed by the specs.

These fixes are still not enough to complete a device auth.