### PR TITLE
OIDC Device Flow does not work when implicit consent is allowed

### DIFF
--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/exceptions/AuthorizationPendingException.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/exceptions/AuthorizationPendingException.java
@@ -25,7 +25,7 @@ public class AuthorizationPendingException extends OAuth2Exception {
      * Constructs a new exception.
      */
     public AuthorizationPendingException() {
-        super(403, "authorization_pending", "The user has not yet completed authorization");
+        super(400, "authorization_pending", "The user has not yet completed authorization");
     }
 
 }


### PR DESCRIPTION
When implicit consent is allowed for an OpenID Client, device flow requests to /access_token always return the error authorization_pending. Moreover, this error is embedded in an HTTP 403 response, while the RFC (https://tools.ietf.org/html/rfc8628#section-3.5) says it should be returned in an HTTP 400 response. If implicit consent is disabled then everything works fine.