### PR TITLE
Close #210: Advertise the device flow authorization endpoint in OIDC metadata

### DIFF
--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2Uris.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2Uris.java
@@ -111,7 +111,6 @@ public interface OAuth2Uris {
      * Returns the default URL for this provider's Device Flow Authorization endpoint.
      *
      * @return The URL.
-     * @throws ServerException If any internal server error occurs.
      */
     String getDeviceAuthorizationEndpoint();
 }

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2Uris.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2Uris.java
@@ -107,4 +107,11 @@ public interface OAuth2Uris {
      */
     String getResourceSetRegistrationEndpoint();
 
+    /**
+     * Returns the default URL for this provider's Device Flow Authorization endpoint.
+     *
+     * @return The URL.
+     * @throws ServerException If any internal server error occurs.
+     */
+    String getDeviceAuthorizationEndpoint();
 }

--- a/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/OAuth2UrisFactory.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/OAuth2UrisFactory.java
@@ -197,5 +197,10 @@ public class OAuth2UrisFactory {
         public String getClientRegistrationEndpoint() {
             return baseUrl + "/connect/register";
         }
+
+        @Override
+        public String getDeviceAuthorizationEndpoint() {
+            return baseUrl + "/device/code";
+        }
     }
 }

--- a/openam-oauth2/src/main/java/org/forgerock/openidconnect/OpenIDConnectProviderConfiguration.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openidconnect/OpenIDConnectProviderConfiguration.java
@@ -100,6 +100,7 @@ public class OpenIDConnectProviderConfiguration {
         configuration.put("acr_values_supported", providerSettings.getAcrMapping().keySet());
         configuration.put("claims_parameter_supported", providerSettings.getClaimsParameterSupported());
         configuration.put("token_endpoint_auth_methods_supported", providerSettings.getEndpointAuthMethodsSupported());
+        configuration.put("device_authorization_endpoint", uris.getDeviceAuthorizationEndpoint());
 
         return new JsonValue(configuration);
     }


### PR DESCRIPTION
The RFC for OIDC Device Flow (https://tools.ietf.org/html/rfc8628#section-4) describes the additional `device_authorization_endpoint` endpoint for device flow authorization to be advertised in the OIDC metadata at `.well-known/openid-configuration`. It is optional, yet it would be nice to publish it.