### PR TITLE
Fix create-realm via cli

### DIFF
--- a/openam-cli/openam-cli-impl/src/main/java/com/sun/identity/cli/CliGuiceModule.java
+++ b/openam-cli/openam-cli-impl/src/main/java/com/sun/identity/cli/CliGuiceModule.java
@@ -27,6 +27,7 @@ import org.forgerock.openam.entitlement.service.EntitlementConfigurationFactory;
 import org.forgerock.openam.entitlement.service.ResourceTypeService;
 import org.forgerock.openam.entitlement.service.ResourceTypeServiceImpl;
 import org.forgerock.openam.entitlement.utils.NullNotificationBroker;
+import org.forgerock.openam.notifications.LocalOnly;
 import org.forgerock.openam.notifications.NotificationBroker;
 import org.forgerock.openam.session.SessionCache;
 
@@ -47,6 +48,7 @@ public class CliGuiceModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(NotificationBroker.class).to(NullNotificationBroker.class);
+        bind(NotificationBroker.class).annotatedWith(LocalOnly.class).to(NullNotificationBroker.class);
         bind(ResourceTypeConfiguration.class).to(ResourceTypeConfigurationImpl.class);
         bind(ResourceTypeService.class).to(ResourceTypeServiceImpl.class);
         bind(ConstraintValidator.class).to(ConstraintValidatorImpl.class);


### PR DESCRIPTION
Closes #153 

Adding ".annotatedWith(LocalOnly.class)" to the existing binding causes other lookups to fail, but adding an additional LocalOnly binding to NullNotificationBroker fixed the error for me.