### PR TITLE
Fix openam-ui tests after submodule commons update

### DIFF
--- a/openam-ui/openam-ui-ria/src/test/js/test-main.js
+++ b/openam-ui/openam-ui-ria/src/test/js/test-main.js
@@ -33,6 +33,7 @@
             "backbone": "/base/target/dependencies/libs/backbone-1.1.2-min",
             "chai": "/base/node_modules/chai/chai",
             "handlebars": "/base/target/dependencies/libs/handlebars-4.4.2",
+            "i18next": "/base/target/dependencies/libs/i18next-1.7.3-min",
             "jquery": "/base/target/dependencies/libs/jquery-2.1.1-min",
             "lodash": "/base/target/dependencies/libs/lodash-3.10.1-min",
             "moment": "/base/target/dependencies/libs/moment-2.8.1-min",


### PR DESCRIPTION
To complete the fix of issue #241, it is necessary to apply this small change in the test configuration to successfully build OpenAM.