### PR TITLE
Allow running with a volume for configuration

### DIFF
--- a/openam-distribution/openam-distribution-docker/Dockerfile
+++ b/openam-distribution/openam-distribution-docker/Dockerfile
@@ -38,7 +38,8 @@ RUN chgrp -R 0 /usr/openam/ && \
 RUN chgrp -R 0 /usr/local/tomcat && \
   chmod -R g=u /usr/local/tomcat
 
-RUN useradd -m -r -u 1001 -g root $OPENAM_USER
+RUN useradd -m -r -u 1001 -g root $OPENAM_USER \
+    && install -d -o $OPENAM_USER $OPENAM_DATA_DIR
 
 USER $OPENAM_USER
 


### PR DESCRIPTION
`$OPENAM_DATA_DIR` does not exist in the image. Because of this, any
volume mounted to that location will be owned by `root` and unwritable
by `$OPENAM_USER`.

By creating this directory (owned by `$OPENAM_USER`), a newly created
volume mounted on `$OPENAM_DATA_DIR` will get its permissions set to
whatever the underlying directory is set to, so OpenAM can write to it.