### PR TITLE
Fix #260 - Correctly retrieve username from the ssoToken

### DIFF
--- a/openam-core/src/main/java/org/forgerock/openam/dpro/session/PartialSessionFactory.java
+++ b/openam-core/src/main/java/org/forgerock/openam/dpro/session/PartialSessionFactory.java
@@ -104,7 +104,7 @@ public class PartialSessionFactory {
     public PartialSession fromSSOToken(SSOToken ssoToken) {
         Builder builder = new Builder();
         try {
-            String universalId = ssoToken.getPrincipal().getName();
+            String universalId = ssoToken.getProperty("sun.am.UniversalIdentifier");
             builder.username(identityUtils.getIdentityName(universalId));
             builder.universalId(universalId);
             builder.realm(dnWrapper.orgNameToRealmName(ssoToken.getProperty("Organization")));


### PR DESCRIPTION
The getSessionInfo endpoint is retrieving the user name by calling the getName method on the user principal, but this only works for users which are authenticated on the internal DataStore. The correct, generic way to retrieve the username is to get the sun.am.UniversalIdentifier property from the ssoToken.