### PR TITLE
Issue 258

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/policy/PolicyUtils.java
+++ b/openam-core/src/main/java/com/sun/identity/policy/PolicyUtils.java
@@ -921,10 +921,10 @@ public class PolicyUtils {
          * Given a value of cn=Accounting Managers,ou=groups,dc=iplanet,dc=com,
          * this method returns com > iplanet > groups > Accounting Managers
          */
-        DN dn = DN.valueOf(strDN);
         if (!LDAPUtils.isDN(strDN)) {
             displayString = strDN;
         } else {
+            DN dn = DN.valueOf(strDN);
             List<RDN> rdns = new ArrayList<>();
             for (RDN rdn : dn) {
                 rdns.add(0, rdn);

--- a/openam-core/src/main/java/org/forgerock/openam/dpro/session/PartialSessionFactory.java
+++ b/openam-core/src/main/java/org/forgerock/openam/dpro/session/PartialSessionFactory.java
@@ -104,7 +104,7 @@ public class PartialSessionFactory {
     public PartialSession fromSSOToken(SSOToken ssoToken) {
         Builder builder = new Builder();
         try {
-            String universalId = ssoToken.getPrincipal().getName();
+            String universalId = ssoToken.getProperty("sun.am.UniversalIdentifier");
             builder.username(identityUtils.getIdentityName(universalId));
             builder.universalId(universalId);
             builder.realm(dnWrapper.orgNameToRealmName(ssoToken.getProperty("Organization")));


### PR DESCRIPTION
From the stacktrace in debug/Configuration:

```
org.forgerock.i18n.LocalizedIllegalArgumentException: The provided value "xtauctionsALL" could not be parsed as a valid distinguished name because the last non-space character was part of the attribute name 'xtauctionsALL'
	at org.forgerock.opendj.ldap.AVA.decode(AVA.java:129)
	at org.forgerock.opendj.ldap.RDN.decode(RDN.java:179)
	at org.forgerock.opendj.ldap.DN.decode(DN.java:272)
	at org.forgerock.opendj.ldap.DN.valueOf(DN.java:245)
	at org.forgerock.opendj.ldap.DN.valueOf(DN.java:214)
	at com.sun.identity.policy.PolicyUtils.getDNDisplayString(PolicyUtils.java:924)
	at com.sun.identity.console.policy.IdentitySubjectAddViewBean.createOptionList(IdentitySubjectAddViewBean.java:223)
	at com.sun.identity.console.policy.IdentitySubjectAddViewBean.beginDisplay(IdentitySubjectAddViewBean.java:113)
```

The method `getDNDisplayString` tries to parse the DN before a preexisting check that verifies if the supplied parameter is actually a valid DN. This PR moves the parsing after the actual check that it's a real DN.