### PR TITLE
Fix #267 - Restore the Persistent Cookie module functionality by returning to the exception-based flow control

### DIFF
--- a/openam-authentication/openam-auth-persistentcookie/src/test/java/org/forgerock/openam/authentication/modules/persistentcookie/PersistentCookieAuthModuleTest.java
+++ b/openam-authentication/openam-auth-persistentcookie/src/test/java/org/forgerock/openam/authentication/modules/persistentcookie/PersistentCookieAuthModuleTest.java
@@ -200,9 +200,8 @@ public class PersistentCookieAuthModuleTest {
         //When
         boolean exceptionCaught = false;
         AuthLoginException exception = null;
-        int res=-1;
         try {
-        	res=persistentCookieAuthModule.process(callbacks, state);
+            persistentCookieAuthModule.process(callbacks, state);
         } catch (AuthLoginException e) {
             exceptionCaught = true;
             exception = e;
@@ -212,9 +211,8 @@ public class PersistentCookieAuthModuleTest {
         verify(amLoginModuleBinder).setUserSessionProperty(JwtSessionModule.TOKEN_IDLE_TIME_IN_MINUTES_CLAIM_KEY, "60");
         verify(amLoginModuleBinder).setUserSessionProperty(JwtSessionModule.MAX_TOKEN_LIFE_IN_MINUTES_KEY, "300");
         verify(persistentCookieWrapper).validateJwtSessionCookie(Matchers.<MessageInfo>anyObject());
-        assertTrue(res==0||exceptionCaught);
-        if (res!=0)
-        	assertEquals(exception.getErrorCode(), "cookieNotValid");
+        assertTrue(exceptionCaught);
+        assertEquals(exception.getErrorCode(), "cookieNotValid");
     }
 
     @Test


### PR DESCRIPTION
This pull request reverts some of the changes to the requirements flow in the Persistent Cookie module. Those modifications were necessary because of a previous bug in how XUI processes requirements, but now the bug is fixed and they prevent the Persistent Cookie module from working correctly.