### PR TITLE
Close #273 - Define a new server property to tell HttpClient classes to use the system proxy

### DIFF
--- a/openam-server-only/src/main/resources/config/validserverconfig.properties
+++ b/openam-server-only/src/main/resources/config/validserverconfig.properties
@@ -338,4 +338,4 @@ org.forgerock.openam.encryption.key.size=128,192,256
 org.forgerock.openam.encryption.key.digest=SHA1,SHA256,SHA384,SHA512
 org.forgerock.openam.radius.server.context.cache.size=integer
 XUI.enable=false,true
-
+org.forgerock.openam.httpclienthandler.system.proxy.enabled=false,true

--- a/openam-server-only/src/main/webapp/WEB-INF/template/sms/serverdefaults.properties
+++ b/openam-server-only/src/main/webapp/WEB-INF/template/sms/serverdefaults.properties
@@ -273,3 +273,4 @@ org.forgerock.openam.encryption.key.iterations=10000
 org.forgerock.openam.encryption.key.size=128
 org.forgerock.openam.encryption.key.digest=SHA1
 org.forgerock.openam.radius.server.context.cache.size=5000
+org.forgerock.openam.httpclienthandler.system.proxy.enabled=false

--- a/openam-shared/src/main/java/com/sun/identity/shared/Constants.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/Constants.java
@@ -1384,4 +1384,9 @@ public interface Constants {
      * The name of the request attribute that tells whether this authentication happened via WS-Fed AR profile.
      */
     String WSFED_ACTIVE_LOGIN = "org.forgerock.openam.federation.wsfed.active.login";
+
+    /**
+     * Property that turns on the system http proxy for HttpClient classes.
+     */
+    public static final String SYSTEM_PROXY_ENABLED = "org.forgerock.openam.httpclienthandler.system.proxy.enabled";
 }

--- a/openam-shared/src/main/java/org/forgerock/openam/shared/guice/CloseableHttpClientHandlerProvider.java
+++ b/openam-shared/src/main/java/org/forgerock/openam/shared/guice/CloseableHttpClientHandlerProvider.java
@@ -1,0 +1,81 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2016 ForgeRock AS.
+ */
+
+package org.forgerock.openam.shared.guice;
+
+import com.google.inject.Provider;
+import com.sun.identity.shared.Constants;
+import com.sun.identity.shared.configuration.SystemPropertiesManager;
+import com.sun.identity.shared.debug.Debug;
+import java.io.IOException;
+import javax.inject.Inject;
+import org.forgerock.http.HttpApplicationException;
+import org.forgerock.http.handler.HttpClientHandler;
+import org.forgerock.util.Options;
+import org.forgerock.util.thread.listener.ShutdownManager;
+
+public class CloseableHttpClientHandlerProvider implements Provider<HttpClientHandler> {
+
+    /** Debug instance for general utility classes. */
+    public static final Debug DEBUG = Debug.getInstance("amUtil");
+
+    /** The commons ShutdownManager. */
+    private ShutdownManager shutdownManager;
+
+    /**
+     * Uses the shutdown manager supplied to register all created HttpClientHandler objects for shutdown.
+     * @param shutdownManager The commons shutdown manager implementation.
+     */
+    @Inject
+    public CloseableHttpClientHandlerProvider(ShutdownManager shutdownManager) {
+        this.shutdownManager = shutdownManager;
+    }
+
+    /**
+     * Creates an instance of HttpClientHandler, assuring that underlying commitments are observer, i.e. listening for shutdown.
+     * @return An instance of HttpClientHandler, or an exception if an error occurred during creation.
+     */
+    @Override
+    public HttpClientHandler get() {
+        try {
+            // Enable the system proxy if the corresponding server property is set
+            Options options = Options.defaultOptions();
+            options.set(HttpClientHandler.OPTION_PROXY_SYSTEM,
+                SystemPropertiesManager.getAsBoolean(Constants.SYSTEM_PROXY_ENABLED, false));
+
+            DEBUG.message("CloseableHttpClientHandlerProvider.get: System proxy enabled for HttpClientHandler: {}",
+                options.get(HttpClientHandler.OPTION_PROXY_SYSTEM));
+
+            HttpClientHandler httpClientHandler = new HttpClientHandler(options);
+
+            // Let the underlying HttpClientHandler clean up it's threads upon shutdown
+            this.shutdownManager.addShutdownListener(() -> {
+                try {
+                    httpClientHandler.close();
+                } catch (IOException e) {
+                    // Abandon attempt to close the connection
+                    DEBUG.message("Unable to close the HttpClientHandler", e);
+                }
+            });
+
+            return httpClientHandler;
+        } catch (HttpApplicationException e) {
+            // Whether this ultimately results in an error is in the hands of the caller
+            DEBUG.error("Unable to create a new HttpClientHandler", e);
+            return null;
+        }
+    }
+}

--- a/openam-shared/src/main/java/org/forgerock/openam/shared/guice/SharedGuiceModule.java
+++ b/openam-shared/src/main/java/org/forgerock/openam/shared/guice/SharedGuiceModule.java
@@ -21,6 +21,7 @@ import javax.inject.Singleton;
 
 import org.forgerock.guice.core.GuiceModule;
 import org.forgerock.http.Client;
+import org.forgerock.http.handler.HttpClientHandler;
 import org.forgerock.openam.audit.context.AMExecutorServiceFactory;
 import org.forgerock.openam.audit.context.AuditRequestContextPropagatingExecutorServiceFactory;
 import org.forgerock.openam.shared.concurrency.ThreadMonitor;
@@ -52,6 +53,7 @@ public class SharedGuiceModule extends AbstractModule {
                 .toInstance(Debug.getInstance(DEBUG_THREAD_MANAGER));
         bind(ShutdownManager.class).toInstance(com.sun.identity.common.ShutdownManager.getInstance());
         bind(KeyPairProviderFactory.class).to(KeyPairProviderFactoryImpl.class);
+        bind(HttpClientHandler.class).toProvider(CloseableHttpClientHandlerProvider.class).in(Scopes.SINGLETON);
         bind(Client.class).toProvider(CloseableHttpClientProvider.class).in(Scopes.SINGLETON);
     }
 


### PR DESCRIPTION
This pull request adds the org.forgerock.openam.httpclienthandler.system.proxy.enabled property to let the HttpClient classes used by the User Self Service component know about JVM proxy settings.