### PR TITLE
Update to LoginState.java. If oldSession is null do not upgrade the session and create a new one.

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/authentication/service/AuthUtils.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/service/AuthUtils.java
@@ -990,13 +990,17 @@ public class AuthUtils extends AuthClientUtils {
                 (sessionUpgrade)) {
                 try {
                     loginState = new LoginState();
-                    InternalSession oldSession = null;
+                    InternalSession oldSession = sess;
                     if (sid != null) {
                         oldSession = AuthD.getSession(sid);
                         loginState.setOldSession(oldSession);
                     }
+		    // #297 Bug. Session Upgrade fails since user is different than original authenticated user
+		    if(oldSession == null) {
+			 oldSession = sess;
+		    }
                     if (sessionUpgrade) {
-                        loginState.setOldSession(oldSession);
+                        loginState.setOldSession(sess);
                         loginState.setSessionUpgrade(sessionUpgrade);
                     }
                     authContext = loginState.createAuthContext(sid,orgName,req);

--- a/openam-core/src/main/java/com/sun/identity/authentication/service/AuthUtils.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/service/AuthUtils.java
@@ -990,7 +990,7 @@ public class AuthUtils extends AuthClientUtils {
                 (sessionUpgrade)) {
                 try {
                     loginState = new LoginState();
-                    InternalSession oldSession = sess;
+                    InternalSession oldSession = null;
                     if (sid != null) {
                         oldSession = AuthD.getSession(sid);
                         loginState.setOldSession(oldSession);
@@ -1000,7 +1000,7 @@ public class AuthUtils extends AuthClientUtils {
 			 oldSession = sess;
 		    }
                     if (sessionUpgrade) {
-                        loginState.setOldSession(sess);
+                        loginState.setOldSession(oldSession);
                         loginState.setSessionUpgrade(sessionUpgrade);
                     }
                     authContext = loginState.createAuthContext(sid,orgName,req);

--- a/openam-core/src/main/java/com/sun/identity/authentication/service/LoginState.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/service/LoginState.java
@@ -1203,6 +1203,11 @@ public class LoginState {
                 }
             }
         }
+	    
+        // Fix for #297 Session Upgrade fails since user is different than original authenticated user
+	if(oldSession == null) {
+		sessionUpgrade = false;
+	} 
 
         if (DEBUG.messageEnabled()) {
             DEBUG.message("LoginState.setSessionProperties()" +

--- a/openam-core/src/main/java/com/sun/identity/authentication/service/LoginState.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/service/LoginState.java
@@ -1203,11 +1203,6 @@ public class LoginState {
                 }
             }
         }
-	    
-        // Fix for #297 Session Upgrade fails since user is different than original authenticated user
-	//if(oldSession == null) {
-	//	sessionUpgrade = false;
-	//} 
 
         if (DEBUG.messageEnabled()) {
             DEBUG.message("LoginState.setSessionProperties()" +

--- a/openam-core/src/main/java/com/sun/identity/authentication/service/LoginState.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/service/LoginState.java
@@ -1205,9 +1205,9 @@ public class LoginState {
         }
 	    
         // Fix for #297 Session Upgrade fails since user is different than original authenticated user
-	if(oldSession == null) {
-		sessionUpgrade = false;
-	} 
+	//if(oldSession == null) {
+	//	sessionUpgrade = false;
+	//} 
 
         if (DEBUG.messageEnabled()) {
             DEBUG.message("LoginState.setSessionProperties()" +


### PR DESCRIPTION
If oldSession is null or oldUserDN is null do not upgrade the session and create a new one.

If user creates 2 different sessions within a few milliseconds, a race condition between threads may occur that can cause a "Session Upgrade fails since user is different than the original authenticated user" exception. oldSession may be null at the point of the session upgrade. If oldSession is null, session upgrade doesn't make sense and sessionUpgrade flag should be set to false to avoid an exception.