### PR TITLE
Fix invalidate internal auth token

### DIFF
--- a/openam-core/src/main/java/com/iplanet/dpro/session/service/InternalSession.java
+++ b/openam-core/src/main/java/com/iplanet/dpro/session/service/InternalSession.java
@@ -360,8 +360,8 @@ public class InternalSession implements Serializable, AMSession, SessionPersiste
      */
     public void setMaxIdleTime(long maxIdleTimeInMinutes) {
     	if (this.maxIdleTimeInMinutes != maxIdleTimeInMinutes) {
-	    	if (willExpireFlag == false && maxIdleTimeInMinutes<NON_EXPIRING_SESSION_LENGTH_MINUTES)
-	    		willExpireFlag = true;
+//	    	if (willExpireFlag == false && maxIdleTimeInMinutes<NON_EXPIRING_SESSION_LENGTH_MINUTES)
+//	    		willExpireFlag = true;
 	            
 	    	this.maxIdleTimeInMinutes = maxIdleTimeInMinutes;
 	        notifyPersistenceManager();

--- a/openam-core/src/main/java/com/iplanet/dpro/session/service/SessionServiceConfig.java
+++ b/openam-core/src/main/java/com/iplanet/dpro/session/service/SessionServiceConfig.java
@@ -102,7 +102,7 @@ public class SessionServiceConfig {
     private static final int DEFAULT_NOTIFICATION_THEAD_POOL_THRESHOLD = DEFAULT_NOTIFICATION_THEAD_POOL_SIZE * 10;
     private final int notificationThreadPoolThreshold;
 
-    private static final long DEFAULT_APPLICATION_MAX_CACHING_TIME = Long.MAX_VALUE / 60;
+    private static final long DEFAULT_APPLICATION_MAX_CACHING_TIME = 10;
     private final long applicationMaxCachingTime;
 
     private static final boolean DEFAULT_RETURN_APP_SESSION = false;


### PR DESCRIPTION
ERROR ru.org.openam.debug.amSMS - OrganizationConfigManager: Unable to get Service Config
com.iplanet.sso.SSOException: SSO Token is not valid.
	at com.iplanet.sso.providers.dpro.SSOProviderImpl.validateToken(SSOProviderImpl.java:323)
	at com.iplanet.sso.SSOTokenManager.validateToken(SSOTokenManager.java:475)
	at com.sun.identity.sm.ServiceConfigManager.<init>(ServiceConfigManager.java:125)