### PR TITLE
Fix #308 Exclude the OIDC checkSession endpoint from iframe sameorigin policy

### DIFF
--- a/openam-server-only/src/main/webapp/WEB-INF/web.xml
+++ b/openam-server-only/src/main/webapp/WEB-INF/web.xml
@@ -62,6 +62,10 @@
             <param-name>X-Frame-Options</param-name>
             <param-value>SAMEORIGIN</param-value>
         </init-param>
+        <init-param>
+            <param-name>excludes</param-name>
+            <param-value>/oauth2/connect/checkSession</param-value>
+        </init-param>
     </filter>
     <filter>
         <filter-name>CacheForFiveMinutes</filter-name>


### PR DESCRIPTION
Adds an exception to the sameorigin policy for the checkSession endpoint.