### PR TITLE
Fix #330 Change URL matching criteria to endsWith

### DIFF
--- a/openam-core/src/main/java/org/forgerock/openam/headers/SetHeadersFilter.java
+++ b/openam-core/src/main/java/org/forgerock/openam/headers/SetHeadersFilter.java
@@ -41,7 +41,6 @@ public class SetHeadersFilter implements Filter {
     private static final String EXCLUDES = "excludes";
     private final Map<String, String> headerKeyValues = new HashMap<String, String>();
     private final Set<String> excludes = new HashSet<String>();
-    private int contextPathLength = 0;
 
     /**
      * Initializes the filter based on the {@link FilterConfig}.
@@ -54,7 +53,6 @@ public class SetHeadersFilter implements Filter {
     @Override
     public void init(FilterConfig config) throws ServletException {
         if (config != null) {
-            contextPathLength = config.getServletContext().getContextPath().length();
             Enumeration<String> initParams = config.getInitParameterNames();
             while (initParams.hasMoreElements()) {
                 String key = initParams.nextElement();
@@ -70,7 +68,7 @@ public class SetHeadersFilter implements Filter {
 
     /**
      * Set HTTP Headers based on the values in the filterConfig init-parameters.
-     * 
+     *
      * {@inheritDoc}
      */
     @Override
@@ -79,7 +77,7 @@ public class SetHeadersFilter implements Filter {
         HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
         HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
 
-        if (!excludes.contains(httpServletRequest.getRequestURI().substring(contextPathLength))) {
+        if (excludes.stream().noneMatch(s -> (httpServletRequest.getRequestURI() != null && httpServletRequest.getRequestURI().endsWith(s)))) {
             for (Map.Entry<String, String> entry : headerKeyValues.entrySet()) {
                 httpServletResponse.addHeader(entry.getKey(), entry.getValue());
             }

--- a/openam-server-only/src/main/webapp/WEB-INF/web.xml
+++ b/openam-server-only/src/main/webapp/WEB-INF/web.xml
@@ -64,7 +64,7 @@
         </init-param>
         <init-param>
             <param-name>excludes</param-name>
-            <param-value>/oauth2/connect/checkSession</param-value>
+            <param-value>/connect/checkSession</param-value>
         </init-param>
     </filter>
     <filter>


### PR DESCRIPTION
Changes the exclude filter from an exact match to an endsWith check. This allows proper exclusion of the checkSession endpoint from iframe SAMEORIGIN policy as required by OIDC specs.