### PR TITLE
Updating base docker image to latest 8.5.x tomcat

### DIFF
--- a/openam-distribution/openam-distribution-docker/Dockerfile
+++ b/openam-distribution/openam-distribution-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.5-jre8
+FROM tomcat:8.5-jdk8
 
 MAINTAINER Open Identity Platform Community <open-identity-platform-openam@googlegroups.com>
 
@@ -16,7 +16,11 @@ ENV VERSION @project_version@
 
 ENV CATALINA_OPTS="-Xmx2048m -server -Dcom.iplanet.services.configpath=$OPENAM_DATA_DIR -Dcom.sun.identity.configuration.directory=$OPENAM_DATA_DIR"
 
-RUN apt-get install -y wget unzip
+RUN apt-get update; \
+    apt-get install -y \
+       wget \
+       unzip \
+       ;
 
 RUN wget --show-progress --progress=bar:force:noscroll --quiet https://github.com/OpenIdentityPlatform/OpenAM/releases/download/$VERSION/OpenAM-$VERSION.war
 


### PR DESCRIPTION
Changing the base docker image to pull from latest tomcat 8.5.x docker image and latest updated java.  The previous tomcat image tag was no longer being maintained (no updates for 2+ years).  Had to change the apt-get install command to also perform an update first since this image did not have the apt repositories updated.

As of writing this commit, this base docker image tag moves the tomcat version from 8.5.41 and java 8u212 to tomcat version 8.5.63 and java 8u282.