### PR TITLE
change log level in DestroySession

### DIFF
--- a/openam-oauth2/src/main/java/org/forgerock/openidconnect/OpenIDConnectProvider.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openidconnect/OpenIDConnectProvider.java
@@ -112,10 +112,10 @@ public class OpenIDConnectProvider {
                 tokenManager.destroyToken(token);
             }
         } catch (CoreTokenException e) {
-            logger.error("Unable to get id_token meta data", e);
+            logger.warn("Unable to get id_token meta data", e);
             throw new ServerException("Unable to get id_token meta data");
         } catch (Exception e) {
-            logger.error("Unable to get SsoTokenManager", e);
+            logger.warn("Unable to get SsoTokenManager", e);
             throw new ServerException("Unable to get SsoTokenManager");
         }
     }


### PR DESCRIPTION
Hi All,

I'd like to suggest you this simple change about log level in destroySession method.

I have an openid connect chain where jwt expiration date is much higher than openam session, so in case of logout (endSession api) I get an exeception in destroySession method.
In this case the exeception is caused about the openam session that is already expired, there isn't any session with that ID.

The effect is to write many useless exceptions to the OAUTHProvider file in the face of many logout / login.
