### PR TITLE
Modified Dockerfile to reduce layers and size

### DIFF
--- a/openam-distribution/openam-distribution-docker/Dockerfile
+++ b/openam-distribution/openam-distribution-docker/Dockerfile
@@ -2,48 +2,34 @@ FROM tomcat:8.5-jdk8
 
 MAINTAINER Open Identity Platform Community <open-identity-platform-openam@googlegroups.com>
 
-ENV CATALINA_HOME /usr/local/tomcat
-
-ENV PATH $CATALINA_HOME/bin:$PATH
+ENV CATALINA_HOME=/usr/local/tomcat \
+    PATH=$CATALINA_HOME/bin:$PATH \
+    OPENAM_USER="openam" \
+    OPENAM_DATA_DIR="/usr/openam/config" \
+    CATALINA_OPTS="-Xmx2048m -server -Dcom.iplanet.services.configpath=$OPENAM_DATA_DIR -Dcom.sun.identity.configuration.directory=$OPENAM_DATA_DIR"
 
 WORKDIR $CATALINA_HOME
 
-ENV OPENAM_USER="openam"
+ARG VERSION @project_version@
 
-ENV OPENAM_DATA_DIR="/usr/openam/config"
-
-ENV VERSION @project_version@
-
-ENV CATALINA_OPTS="-Xmx2048m -server -Dcom.iplanet.services.configpath=$OPENAM_DATA_DIR -Dcom.sun.identity.configuration.directory=$OPENAM_DATA_DIR"
-
-RUN apt-get update; \
-    apt-get install -y \
-       wget \
-       unzip \
-       ;
-
-RUN wget --show-progress --progress=bar:force:noscroll --quiet https://github.com/OpenIdentityPlatform/OpenAM/releases/download/$VERSION/OpenAM-$VERSION.war
-
-RUN mv *.war $CATALINA_HOME/webapps/openam.war
-
-RUN mkdir /usr/openam
-
-RUN wget --show-progress --progress=bar:force:noscroll --quiet --output-document=/usr/openam/ssoconfiguratortools.zip https://github.com/OpenIdentityPlatform/OpenAM/releases/download/$VERSION/SSOConfiguratorTools-$VERSION.zip \
+RUN apt-get update && apt-get install -y \
+    wget \
+    unzip \
+ && rm -rf /var/lib/apt/lists/* \
+ && wget --show-progress --progress=bar:force:noscroll --quiet --output-document=$CATALINA_HOME/webapps/openam.war https://github.com/OpenIdentityPlatform/OpenAM/releases/download/$VERSION/OpenAM-$VERSION.war \
+ && mkdir /usr/openam \
+ && wget --show-progress --progress=bar:force:noscroll --quiet --output-document=/usr/openam/ssoconfiguratortools.zip https://github.com/OpenIdentityPlatform/OpenAM/releases/download/$VERSION/SSOConfiguratorTools-$VERSION.zip \
  && unzip /usr/openam/ssoconfiguratortools.zip -d /usr/openam/ssoconfiguratortools \
- && rm /usr/openam/ssoconfiguratortools.zip
-
-RUN wget --show-progress --progress=bar:force:noscroll --quiet --output-document=/usr/openam/ssoadmintools.zip https://github.com/OpenIdentityPlatform/OpenAM/releases/download/$VERSION/SSOAdminTools-$VERSION.zip \
+ && rm /usr/openam/ssoconfiguratortools.zip \
+ && wget --show-progress --progress=bar:force:noscroll --quiet --output-document=/usr/openam/ssoadmintools.zip https://github.com/OpenIdentityPlatform/OpenAM/releases/download/$VERSION/SSOAdminTools-$VERSION.zip \
  && unzip /usr/openam/ssoadmintools.zip -d /usr/openam/ssoadmintools \
- && rm /usr/openam/ssoadmintools.zip
-
-RUN chgrp -R 0 /usr/openam/ && \
-  chmod -R g=u /usr/openam/
-
-RUN chgrp -R 0 /usr/local/tomcat && \
-  chmod -R g=u /usr/local/tomcat
-
-RUN useradd -m -r -u 1001 -g root $OPENAM_USER \
-    && install -d -o $OPENAM_USER $OPENAM_DATA_DIR
+ && rm /usr/openam/ssoadmintools.zip \
+ && chgrp -R 0 /usr/openam/ \
+ && chmod -R g=u /usr/openam/ \
+ && chgrp -R 0 /usr/local/tomcat \
+ && chmod -R g=u /usr/local/tomcat \
+ && useradd -m -r -u 1001 -g root $OPENAM_USER \
+ && install -d -o $OPENAM_USER $OPENAM_DATA_DIR
 
 USER $OPENAM_USER
 

--- a/openam-distribution/openam-distribution-docker/README.md
+++ b/openam-distribution/openam-distribution-docker/README.md
@@ -1,7 +1,7 @@
 # How-to:
 Build docker image:
 
-    docker build . -t openidentityplatform/openam
+    docker build . -t openidentityplatform/openam --build-arg VERSION=OPENAM_RELEASE
 
 Run image
 


### PR DESCRIPTION
Hi all,

I think this change can improve OpenAM docker image, from local tests the image size gets reduced from 1.58GB to 937MB.

I also substituted:
`ENV VERSION @project_version@`
with
`ARG VERSION @project_version@`
to be able to build the image locally without having to change the Dockerfile or run maven to replace '@project_version@' token (I updated readme file as well).

With these changes by default it will work as it used to, but it's possible to build an image with:
`docker build . -t openidentityplatform/openam --build-arg VERSION=OPENAM_RELEASE`
e.g.: 
`docker build . -t openidentityplatform/openam --build-arg VERSION=14.6.3`