### PR TITLE
Assertion conditions with skew

### DIFF
--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/assertion/Conditions.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/assertion/Conditions.java
@@ -149,6 +149,18 @@ public interface Conditions {
      */
     public boolean checkDateValidity(long someTime);
 
+    /**
+     * Return true if a specific Date falls within the validity 
+     * interval of this set of conditions.
+     *
+     * @param someTime a time in milliseconds.
+     * @param skew allowed clock skew in seconds.
+     *  
+     * @return true if <code>someTime</code> is within the valid 
+     * interval of the <code>Conditions</code>.     
+     */
+    boolean checkDateValidity(long someTime, int skew);
+    
    /**
     * Returns a String representation
     * @param includeNSPrefix Determines whether or not the namespace

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/assertion/impl/ConditionsImpl.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/assertion/impl/ConditionsImpl.java
@@ -350,31 +350,45 @@ public class ConditionsImpl implements Conditions {
      * Return true if a specific Date falls within the validity 
      * interval of this set of conditions.
      *
-     * @param someTime Any time in milliseconds. 
+     * @param someTime Any time in milliseconds.
+     * @param skewSeconds Clock skew in seconds. 
      * @return true if <code>someTime</code> is within the valid 
      * interval of the <code>Conditions</code>.     
      */
-    public boolean checkDateValidity(long someTime) {
+    public boolean checkDateValidity(long someTime, int skewSeconds) {
+    	int skew = skewSeconds * 1000;
         if (notBefore == null ) {
             if (notOnOrAfter == null) {
                 return true;
             } else {
-                if (someTime < notOnOrAfter.getTime()) {
+                if (someTime < notOnOrAfter.getTime() + skew) {
                     return true;
                 }
             }
         } else if (notOnOrAfter == null ) {
-            if (someTime >= notBefore.getTime()) {
+            if (someTime >= notBefore.getTime() - skew) {
                 return true;
             }
-        } else if ((someTime >= notBefore.getTime()) && 
-            (someTime < notOnOrAfter.getTime()))
+        } else if ((someTime >= notBefore.getTime() - skew) && 
+            (someTime < notOnOrAfter.getTime() + skew))
         {
             return true; 
         }
         return false;
     }
 
+    /**
+     * Return true if a specific Date falls within the validity 
+     * interval of this set of conditions.
+     *
+     * @param someTime Any time in milliseconds. 
+     * @return true if <code>someTime</code> is within the valid 
+     * interval of the <code>Conditions</code>.     
+     */
+    public boolean checkDateValidity(long someTime) {
+    	return checkDateValidity(someTime, 0);
+    }
+    
    /**
     * Returns a String representation
     * @param includeNSPrefix Determines whether or not the namespace 

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/common/SAML2Constants.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/common/SAML2Constants.java
@@ -1114,7 +1114,7 @@ public interface SAML2Constants {
      */
     public String SP_AUTHCONTEXT_COMPARISON = "AuthComparison";
 
-    // Time Skew for Assertion NotOnOrAfter. In seconds.
+    // Time Skew for Assertion NotOnOrAfter and Condition NotBefore, NotOnOrAfter. In seconds.
     public String ASSERTION_TIME_SKEW = "assertionTimeSkew";
     public int ASSERTION_TIME_SKEW_DEFAULT = 300;
 

--- a/openam-federation/openam-federation-library/src/test/java/com/sun/identity/saml2/assertion/impl/ConditionsImplTest.java
+++ b/openam-federation/openam-federation-library/src/test/java/com/sun/identity/saml2/assertion/impl/ConditionsImplTest.java
@@ -6,8 +6,7 @@
  * (the License). You may not use this file except in
  * compliance with the License.
  *
- * You can obtain a copy of the License at
- * https://github.com/OpenIdentityPlatform/OpenAM/blob/master/LICENSE.md
+ * You can obtain a copy of the License at LICENSE.md
  * See the License for the specific language governing
  * permission and limitations under the License.
  *

--- a/openam-federation/openam-federation-library/src/test/java/com/sun/identity/saml2/assertion/impl/ConditionsImplTest.java
+++ b/openam-federation/openam-federation-library/src/test/java/com/sun/identity/saml2/assertion/impl/ConditionsImplTest.java
@@ -1,3 +1,17 @@
+/**
+ * DO NOT ALTER OR REMOVE THIS HEADER.
+ *
+ * The contents of this file are subject to the terms
+ * of the Common Development and Distribution License
+ * (the License). You may not use this file except in
+ * compliance with the License.
+ *
+ * You can obtain a copy of the License at
+ * https://github.com/OpenIdentityPlatform/OpenAM/blob/master/LICENSE.md
+ * See the License for the specific language governing
+ * permission and limitations under the License.
+ *
+ */
 package com.sun.identity.saml2.assertion.impl;
 
 import static org.testng.Assert.assertTrue;
@@ -25,12 +39,22 @@ public class ConditionsImplTest {
 	}
 
 	@Test
+	public void testSuccess() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
+		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
+
+		long instant = validFrom.plusSeconds(30).toEpochMilli();
+		assertTrue(conditions.checkDateValidity(instant));
+	}
+
+	@Test
 	public void testTooEarly() throws Exception {
 		Conditions conditions = new ConditionsImpl();
 		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
 
-		long now = new Date(validFrom.minusSeconds(30).toEpochMilli()).getTime();
-		assertFalse(conditions.checkDateValidity(now));
+		long instant = validFrom.minusSeconds(30).toEpochMilli();
+		assertFalse(conditions.checkDateValidity(instant));
 	}
 
 	@Test
@@ -38,8 +62,8 @@ public class ConditionsImplTest {
 		Conditions conditions = new ConditionsImpl();
 		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
 
-		long now = new Date(validFrom.minusSeconds(30).toEpochMilli()).getTime();
-		assertTrue(conditions.checkDateValidity(now, SKEW_60S));
+		long instant = validFrom.minusSeconds(30).toEpochMilli();
+		assertTrue(conditions.checkDateValidity(instant, SKEW_60S));
 	}
 
 	@Test
@@ -47,8 +71,8 @@ public class ConditionsImplTest {
 		Conditions conditions = new ConditionsImpl();
 		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
 
-		long now = new Date(validFrom.minusSeconds(80).toEpochMilli()).getTime();
-		assertFalse(conditions.checkDateValidity(now, SKEW_60S));
+		long instant = validFrom.minusSeconds(80).toEpochMilli();
+		assertFalse(conditions.checkDateValidity(instant, SKEW_60S));
 	}
 
 	@Test
@@ -56,8 +80,8 @@ public class ConditionsImplTest {
 		Conditions conditions = new ConditionsImpl();
 		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
 		
-		long now = new Date(validTo.plusSeconds(30).toEpochMilli()).getTime();
-		assertFalse(conditions.checkDateValidity(now));
+		long instant = validTo.plusSeconds(30).toEpochMilli();
+		assertFalse(conditions.checkDateValidity(instant));
 	}
 
 	@Test
@@ -65,8 +89,8 @@ public class ConditionsImplTest {
 		Conditions conditions = new ConditionsImpl();
 		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
 		
-		long now = new Date(validTo.plusSeconds(30).toEpochMilli()).getTime();
-		assertTrue(conditions.checkDateValidity(now, SKEW_60S));
+		long instant = validTo.plusSeconds(30).toEpochMilli();
+		assertTrue(conditions.checkDateValidity(instant, SKEW_60S));
 	}
 
 	@Test
@@ -74,8 +98,8 @@ public class ConditionsImplTest {
 		Conditions conditions = new ConditionsImpl();
 		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
 		
-		long now = new Date(validTo.plusSeconds(80).toEpochMilli()).getTime();
-		assertFalse(conditions.checkDateValidity(now, SKEW_60S));
+		long instant = validTo.plusSeconds(80).toEpochMilli();
+		assertFalse(conditions.checkDateValidity(instant, SKEW_60S));
 	}
 	
 	@Test
@@ -84,8 +108,8 @@ public class ConditionsImplTest {
 		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
 		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
 
-		long now = new Date(validFrom.minusSeconds(30).toEpochMilli()).getTime();
-		assertFalse(conditions.checkDateValidity(now));
+		long instant = validFrom.minusSeconds(30).toEpochMilli();
+		assertFalse(conditions.checkDateValidity(instant));
 	}
 
 	@Test
@@ -94,8 +118,8 @@ public class ConditionsImplTest {
 		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
 		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
 
-		long now = new Date(validFrom.minusSeconds(30).toEpochMilli()).getTime();
-		assertTrue(conditions.checkDateValidity(now, SKEW_60S));
+		long instant = validFrom.minusSeconds(30).toEpochMilli();
+		assertTrue(conditions.checkDateValidity(instant, SKEW_60S));
 	}
 
 	@Test
@@ -104,8 +128,8 @@ public class ConditionsImplTest {
 		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
 		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
 
-		long now = new Date(validFrom.minusSeconds(80).toEpochMilli()).getTime();
-		assertFalse(conditions.checkDateValidity(now, SKEW_60S));
+		long instant = validFrom.minusSeconds(80).toEpochMilli();
+		assertFalse(conditions.checkDateValidity(instant, SKEW_60S));
 	}
 
 	@Test
@@ -114,28 +138,28 @@ public class ConditionsImplTest {
 		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
 		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
 		
-		long now = new Date(validTo.plusSeconds(30).toEpochMilli()).getTime();
-		assertFalse(conditions.checkDateValidity(now));
+		long instant = validTo.plusSeconds(30).toEpochMilli();
+		assertFalse(conditions.checkDateValidity(instant));
 	}
 
 	@Test
-	public void testNotTooLateWitkSkewForRange() throws Exception {
+	public void testNotTooLateWithSkewForRange() throws Exception {
 		Conditions conditions = new ConditionsImpl();
 		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
 		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
 		
-		long now = new Date(validTo.plusSeconds(30).toEpochMilli()).getTime();
-		assertTrue(conditions.checkDateValidity(now, SKEW_60S));
+		long instant = validTo.plusSeconds(30).toEpochMilli();
+		assertTrue(conditions.checkDateValidity(instant, SKEW_60S));
 	}
 
 	@Test
-	public void testTooLateWitkSkewForRange() throws Exception {
+	public void testTooLateWithSkewForRange() throws Exception {
 		Conditions conditions = new ConditionsImpl();
 		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
 		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
 		
-		long now = new Date(validTo.plusSeconds(80).toEpochMilli()).getTime();
-		assertFalse(conditions.checkDateValidity(now, SKEW_60S));
+		long instant = validTo.plusSeconds(80).toEpochMilli();
+		assertFalse(conditions.checkDateValidity(instant, SKEW_60S));
 	}
 
 	@Test
@@ -144,8 +168,8 @@ public class ConditionsImplTest {
 		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
 		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
 		
-		long now = new Date(validFrom.toEpochMilli()).getTime();
-		assertTrue(conditions.checkDateValidity(now));
+		long instant = validFrom.toEpochMilli();
+		assertTrue(conditions.checkDateValidity(instant));
 	}
 	
 	@Test
@@ -154,7 +178,7 @@ public class ConditionsImplTest {
 		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
 		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
 		
-		long now = new Date(validTo.minusSeconds(1).toEpochMilli()).getTime();
-		assertTrue(conditions.checkDateValidity(now));
+		long instant = validTo.minusSeconds(1).toEpochMilli();
+		assertTrue(conditions.checkDateValidity(instant));
 	}
 }

--- a/openam-federation/openam-federation-library/src/test/java/com/sun/identity/saml2/assertion/impl/ConditionsImplTest.java
+++ b/openam-federation/openam-federation-library/src/test/java/com/sun/identity/saml2/assertion/impl/ConditionsImplTest.java
@@ -1,0 +1,160 @@
+package com.sun.identity.saml2.assertion.impl;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
+
+import java.time.Instant;
+import java.util.Date;
+
+import org.testng.annotations.Test;
+
+import com.sun.identity.saml2.assertion.Conditions;
+
+public class ConditionsImplTest {
+
+	private static final int SKEW_60S = 60; // 60 s of clock skew
+
+	private final Instant validFrom = Instant.now();
+	private final Instant validTo = validFrom.plusSeconds(180);
+
+	@Test
+	public void testVoid() {
+		Conditions conditions = new ConditionsImpl();
+
+		assertTrue(conditions.checkDateValidity(Instant.now().toEpochMilli()));
+	}
+
+	@Test
+	public void testTooEarly() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
+
+		long now = new Date(validFrom.minusSeconds(30).toEpochMilli()).getTime();
+		assertFalse(conditions.checkDateValidity(now));
+	}
+
+	@Test
+	public void testNotTooEarlyWithSkew() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
+
+		long now = new Date(validFrom.minusSeconds(30).toEpochMilli()).getTime();
+		assertTrue(conditions.checkDateValidity(now, SKEW_60S));
+	}
+
+	@Test
+	public void testTooEarlyWithSkew() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
+
+		long now = new Date(validFrom.minusSeconds(80).toEpochMilli()).getTime();
+		assertFalse(conditions.checkDateValidity(now, SKEW_60S));
+	}
+
+	@Test
+	public void testTooLate() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
+		
+		long now = new Date(validTo.plusSeconds(30).toEpochMilli()).getTime();
+		assertFalse(conditions.checkDateValidity(now));
+	}
+
+	@Test
+	public void testNotTooLateWithSkew() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
+		
+		long now = new Date(validTo.plusSeconds(30).toEpochMilli()).getTime();
+		assertTrue(conditions.checkDateValidity(now, SKEW_60S));
+	}
+
+	@Test
+	public void testTooLateWithSkew() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
+		
+		long now = new Date(validTo.plusSeconds(80).toEpochMilli()).getTime();
+		assertFalse(conditions.checkDateValidity(now, SKEW_60S));
+	}
+	
+	@Test
+	public void testTooEarlyForRange() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
+		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
+
+		long now = new Date(validFrom.minusSeconds(30).toEpochMilli()).getTime();
+		assertFalse(conditions.checkDateValidity(now));
+	}
+
+	@Test
+	public void testNotTooEarlyWithSkewForRange() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
+		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
+
+		long now = new Date(validFrom.minusSeconds(30).toEpochMilli()).getTime();
+		assertTrue(conditions.checkDateValidity(now, SKEW_60S));
+	}
+
+	@Test
+	public void testTooEarlyWithSkewForRange() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
+		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
+
+		long now = new Date(validFrom.minusSeconds(80).toEpochMilli()).getTime();
+		assertFalse(conditions.checkDateValidity(now, SKEW_60S));
+	}
+
+	@Test
+	public void testTooLateForRange() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
+		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
+		
+		long now = new Date(validTo.plusSeconds(30).toEpochMilli()).getTime();
+		assertFalse(conditions.checkDateValidity(now));
+	}
+
+	@Test
+	public void testNotTooLateWitkSkewForRange() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
+		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
+		
+		long now = new Date(validTo.plusSeconds(30).toEpochMilli()).getTime();
+		assertTrue(conditions.checkDateValidity(now, SKEW_60S));
+	}
+
+	@Test
+	public void testTooLateWitkSkewForRange() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
+		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
+		
+		long now = new Date(validTo.plusSeconds(80).toEpochMilli()).getTime();
+		assertFalse(conditions.checkDateValidity(now, SKEW_60S));
+	}
+
+	@Test
+	public void testSpotOn() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
+		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
+		
+		long now = new Date(validFrom.toEpochMilli()).getTime();
+		assertTrue(conditions.checkDateValidity(now));
+	}
+	
+	@Test
+	public void testJustInTime() throws Exception {
+		Conditions conditions = new ConditionsImpl();
+		conditions.setNotBefore(new Date(validFrom.toEpochMilli()));
+		conditions.setNotOnOrAfter(new Date(validTo.toEpochMilli()));
+		
+		long now = new Date(validTo.minusSeconds(1).toEpochMilli()).getTime();
+		assertTrue(conditions.checkDateValidity(now));
+	}
+}


### PR DESCRIPTION
### Allow for clock skew when verifying time validity in assertion condition

When checking the current time against the NotBefore and NotOnOrAfter assertion conditions, the `assertionTimeSkew` configured for SP (default: 300 s) is now taken into account.

This fixes #98
