### PR TITLE
Do not validate time when handling unexpected NotBefore attribute

### DIFF
--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/common/SAML2Utils.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/common/SAML2Utils.java
@@ -725,19 +725,15 @@ public class SAML2Utils extends SAML2SDKUtils {
 
             Date notBefore = subjectConfData.getNotBefore();
             if (notBefore != null) {
-                if ((notBefore.getTime() + timeskew * 1000) >
-                        currentTimeMillis()) {
-                    if (debug.messageEnabled()) {
-                        debug.message(method + "SubjectConfirmationData included "
-                                + "NotBefore.");
-                    }
-                    String[] data = {assertionID};
-                    LogUtil.error(Level.INFO, LogUtil.CONTAINED_NOT_BEFORE, data, null);
-                    throw new SAML2Exception(bundle.getString(
-                            "containedNotBefore"));
+                if (debug.messageEnabled()) {
+                    debug.message(method + "SubjectConfirmationData included "
+                            + "NotBefore.");
                 }
+                String[] data = {assertionID};
+                LogUtil.error(Level.INFO, LogUtil.CONTAINED_NOT_BEFORE, data, null);
+                throw new SAML2Exception(bundle.getString(
+                        "containedNotBefore"));
             }
-            retMap.put(SAML2Constants.NOTBEFORE, notBefore);
 
             String inRespTo = subjectConfData.getInResponseTo();
             if (inRespTo != null && inRespTo.length() != 0) {


### PR DESCRIPTION
According to http://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf, the SubjectConfirmation element _MUST NOT contain a NotBefore attribute_. SAML2Utils correctly throws an exception when NotBefore is present, however before doing so, it also checks time validity against the attribute value! This does not make sense.