### PR TITLE
Update external dependency to https protocol

### DIFF
--- a/openam-ui/pom.xml
+++ b/openam-ui/pom.xml
@@ -116,7 +116,7 @@
 							<version>1.0</version>
 							<packaging>js</packaging>
 							<downloadUrl>
-								http://www.eyecon.ro/bootstrap-tabdrop/js/bootstrap-tabdrop.js
+								https://www.eyecon.ro/bootstrap-tabdrop/js/bootstrap-tabdrop.js
 							</downloadUrl>
 						</artifactItem>
 						<artifactItem>


### PR DESCRIPTION
Update external dependency Bootstrap Tabdrop URL to https. 
Fixes #401 .