### PR TITLE
Fix #475 Apache ActiveMQ client switched to Java 11 only for release 5.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <json.version>20090211</json.version>
     <hikaricp.version>2.4.1</hikaricp.version>
     <h2database.version>2.1.210</h2database.version>
-    <activemq.version>[5.15.9,)</activemq.version>
+    <activemq.version>[5.15.9,5.17)</activemq.version>
     <javax.inject.version>1_2</javax.inject.version>
     <jetty.jspc.version>9.4.0.M0</jetty.jspc.version>
     <amazon.sns.version>1.10.72</amazon.sns.version>


### PR DESCRIPTION
Limit the upper bound for Apache ActiveMQ client in the pom to release 5.16.x as release 5.17 switched to Java11 only.