### PR TITLE
CVE-2023-34453 CVE-2023-34454 CVE-2023-34455 snappy-java's Overflow vulnerability

### DIFF
--- a/openam-cassandra/pom.xml
+++ b/openam-cassandra/pom.xml
@@ -59,7 +59,7 @@
 			<dependency>
 			    <groupId>org.xerial.snappy</groupId>
 			    <artifactId>snappy-java</artifactId>
-			    <version>1.1.8.4</version>
+			    <version>1.1.10.1</version>
 			</dependency>
 			<dependency>
 			    <groupId>com.google.guava</groupId>


### PR DESCRIPTION
CVE-2023-34453 snappy-java's Integer Overflow vulnerability in shuffle
CVE-2023-34454 snappy-java's Integer Overflow vulnerability in compress leads to DoS
CVE-2023-34455 snappy-java's unchecked chunk length leads to DoS