### PR TITLE
Avoid NPE by skipping attributes that are not in schema

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsJsonConverter.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsJsonConverter.java
@@ -393,7 +393,7 @@ public class SmsJsonConverter {
 
     private boolean shouldBeIgnored(String attributeName) {
         final AttributeSchema attributeSchema = schema.getAttributeSchema(attributeName);
-        return (attributeSchema != null && StringUtils.isBlank(attributeSchema.getI18NKey())) || attributeName.equals
+        return (attributeSchema == null || StringUtils.isBlank(attributeSchema.getI18NKey())) || attributeName.equals
                 ("_type") || hiddenAttributeNames.contains(attributeName);
     }
 


### PR DESCRIPTION
Fixes #653.

Related to 281c1d71 (OPENAM-8616).

For some reason, the logic for shouldBeIgnored() was changed. However, this reacts poorly with SmsJsonConverter.toJson(), where a NPE occurs if the input contains an attribute that is not part of the schema. In this case, the attribute was "cospriority". This attribute is added in classes like [AMIdentity.java](https://github.com/OpenIdentityPlatform/OpenAM/blob/f490d06f4f54de81d3d8ceaa08d11c7f3fe9703d/openam-core/src/main/java/com/sun/identity/idm/AMIdentity.java#L1479), but is not part of the amSession.xml schema.