### PR TITLE
Policy filter fix

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/common/util/BackgridUtils.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/common/util/BackgridUtils.js
@@ -250,23 +250,23 @@ define([
         if (data === undefined) { data = {}; }
 
         var params = [],
-            additionalFilters = data._queryFilter || [];
-//            getFilter = (function () {
-//                return data && data.filterName && data.filterName === "eq"
-//                    ? function (filterName, filterQuery) {
-//                        // Policies endpoints do not support 'co', so we emulate it using 'eq' and wildcards
-//                        return `${filterName}+eq+${encodeURIComponent(`"*${filterQuery}*"`)}`;
-//                    }
-//                    : function (filterName, filterQuery) {
-//                        return `${filterName}+co+${encodeURIComponent(`"${filterQuery}"`)}`;
-//                    };
-//            }());
+            additionalFilters = data._queryFilter || [],
+            getFilter = (function () {
+                return data && data.filterName && data.filterName === "eq"
+                    ? function (filterName, filterQuery) {
+                        // Policies endpoints do not support 'co', so we emulate it using 'eq' and wildcards
+                        return `${filterName}+eq+${encodeURIComponent(`"*${filterQuery}*"`)}`;
+                    }
+                    : function (filterName, filterQuery) {
+                        return `${filterName}+co+${encodeURIComponent(`"${filterQuery}"`)}`;
+                    };
+            }());
 
-//        _.each(this.state.filters, function (filter) {
-//            if (filter.query() !== "") {
-//                params.push(getFilter(filter.name, filter.query()));
-//            }
-//        });
+        _.each(this.state.filters, function (filter) {
+            if (filter.query() !== "") {
+                params.push(getFilter(filter.name, filter.query()));
+            }
+        });
         params = params.concat(additionalFilters);
 
         return params.length === 0 ? true : params.join("+AND+");


### PR DESCRIPTION
To fix #655, reinstate the policy filter, as policies cannot be filtered.

Since it's unclear why the policy filter logic itself was disabled back in 2018, please don't merge this until we are sure it will not bring back the original problem. For now, this will serve to illustrate what I did.