### PR TITLE
Fix inability to retrieve the token ID of the token used in the session

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/session/TokenOwnerAuthzModule.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/session/TokenOwnerAuthzModule.java
@@ -140,7 +140,7 @@ public class TokenOwnerAuthzModule implements CrestAuthorizationModule {
         String tokenId =  request.getResourcePath(); // infer from the token from resource path
         if (StringUtils.isEmpty(tokenId)) {
             //if there's no tokenId then is it supplied as additional parameter
-            tokenId = request.getAdditionalParameter(tokenIdParameter);
+            tokenId = SessionResourceUtil.getTokenID(context, request);
         }
 
         final String queryUsername = ssoTokenManager.createSSOToken(tokenId).getProperty(Constants.UNIVERSAL_IDENTIFIER);


### PR DESCRIPTION
For the /sessions API.

This should make this part of OpenAM function more similarly to AM 5.
Note: 5.5 introduced the ability to read the token from the body as part of the /sessions API resource 3.0, which is not included in this commit.

I haven't tested much, but it seems to do the job & lets IG 6.5.3 interface with OpenAM, which was previously not working because it wouldn't retrieve the token ID of the session without an explicit tokenId request parameter. If the goal is to let AM authenticate the request with the session's token, then this seems to do the job.

Related to #305.