### PR TITLE
Append the IdType (membershipType/memberType) to the cache key

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/idm/server/IdCachedServicesImpl.java
+++ b/openam-core/src/main/java/com/sun/identity/idm/server/IdCachedServicesImpl.java
@@ -458,7 +458,7 @@ public class IdCachedServicesImpl extends IdServicesImpl implements IdCachedServ
 
     @Override
     public Set getMembers(SSOToken token, IdType type, String name, String amOrgName, IdType membersType, String amsdkDN) throws IdRepoException, SSOException {
-        final String key=new AMIdentity(token, name, type, amOrgName, amsdkDN).getUniversalId().toLowerCase();
+        final String key=(new AMIdentity(token, name, type, amOrgName, amsdkDN).getUniversalId() + "_" + membersType.getName()).toLowerCase();
         Set res = idRepoMembers.getIfPresent(key);
         if (res == null) {
             if (DEBUG.messageEnabled()) {
@@ -468,12 +468,18 @@ public class IdCachedServicesImpl extends IdServicesImpl implements IdCachedServ
             res=super.getMembers(token, type, name, amOrgName, membersType, amsdkDN);;
             idRepoMembers.put(key, res);
         }
+        else {
+            if (DEBUG.messageEnabled()) {
+                DEBUG.message("IdCachedServicesImpl.getMembers(): "
+                        + "Cache hit for key = " + key + ".");
+            }
+        }
         return new HashSet(res);
     }
 
     @Override
     public Set getMemberships(SSOToken token, IdType type, String name, IdType membershipType, String amOrgName, String amsdkDN) throws IdRepoException, SSOException {
-        final String key=new AMIdentity(token, name, type, amOrgName, amsdkDN).getUniversalId().toLowerCase();
+        final String key=(new AMIdentity(token, name, type, amOrgName, amsdkDN).getUniversalId() + "_" + membershipType.getName()).toLowerCase();
         Set res = idRepoMemberships.getIfPresent(key);
         if (res == null) {
             if (DEBUG.messageEnabled()) {
@@ -482,6 +488,12 @@ public class IdCachedServicesImpl extends IdServicesImpl implements IdCachedServ
             }
             res = super.getMemberships(token, type, name, membershipType, amOrgName, amsdkDN);
             idRepoMemberships.put(key, res);
+        }
+        else {
+            if (DEBUG.messageEnabled()) {
+                DEBUG.message("IdCachedServicesImpl.getMemberships(): "
+                        + "Cache hit for key = " + key + ".");
+            }
         }
         return new HashSet(res);
     }


### PR DESCRIPTION
This should fix #662.

Append the IdType (membershipType/memberType) to the cache key, to avoid mixing up the result sets.
Previously, IdCachedServicesImpl's getMembers() and getMembership() did not consider the IdType, thus the results could get mixed up, leading to unexpected behaviour if the results would differ. Consequences may include a temporary inability of AM to correctly evaluate policies, resulting in correct enforcement of policies by the gateway. The result of the policy evaluation may also be cached, making the issue last longer than the lifespan of the entry within the cache.

The IdType is now suffixed to the key. For example, these would have been equivalent, without the change:
```
IdCachedServicesImpl.getMemberships(): Cache hit for key = id=admin,ou=user,o=iot_platform,o=wisx,ou=services,dc=openam,dc=forgerock,dc=org_role.
IdCachedServicesImpl.getMemberships(): Cache hit for key = id=admin,ou=user,o=iot_platform,o=wisx,ou=services,dc=openam,dc=forgerock,dc=org_group.
```