### PR TITLE
Session constraint fixes

### DIFF
--- a/openam-core/src/main/java/com/iplanet/dpro/session/service/SessionConstraint.java
+++ b/openam-core/src/main/java/com/iplanet/dpro/session/service/SessionConstraint.java
@@ -92,9 +92,11 @@ public class SessionConstraint {
     static SessionQueryManager sqm=null;
    
     static QuotaExhaustionAction getQuotaExhaustionAction() {
-    		if (quotaExhaustionAction != null) 
-            return quotaExhaustionAction;
         String clazzName = InjectorHolder.getInstance(SessionServiceConfig.class).getConstraintHandler();
+        if (quotaExhaustionAction != null
+               && quotaExhaustionAction.getClass().getName().equals(clazzName)) 
+            return quotaExhaustionAction;
+
         try {
             quotaExhaustionAction = Class.forName(clazzName).asSubclass(QuotaExhaustionAction.class).newInstance();
         } catch (Exception ex) {

--- a/openam-core/src/main/java/com/iplanet/dpro/session/service/SessionConstraint.java
+++ b/openam-core/src/main/java/com/iplanet/dpro/session/service/SessionConstraint.java
@@ -144,8 +144,11 @@ public class SessionConstraint {
          // Step 3: checking the constraints
             if (sessions != null && SystemProperties.getAsBoolean("org.openidentityplatform.openam.cts.quota.exhaustion.enabled", true)) {
             		sessions.remove(internalSession.getSessionID().toString());
-	    	        while (sessions.size() >= quota) 
+	    	        while (sessions.size() >= quota) {
 	    	            reject = getQuotaExhaustionAction().action(internalSession, sessions);
+	    	            if (reject)
+	    	                break;
+	    	        }
             }
         } catch (Exception e) {
             if (InjectorHolder.getInstance(SessionServiceConfig.class).isDenyLoginIfDBIsDown()) {


### PR DESCRIPTION
Fixes #145, whereby the DENY condition results in a deadlock due to a while loop with no exit condition. Since the goal is to deny session creation, the loop should be exited.

This PR also fixes an issue that was introduced long ago, which caused changes to this specific setting to require a restart of OpenAM to become binding.