### PR TITLE
[#368] Avoid NPE if the PrivateKey cannot be loaded.

### DIFF
--- a/openam-shared/src/main/java/org/forgerock/openam/utils/AMKeyProvider.java
+++ b/openam-shared/src/main/java/org/forgerock/openam/utils/AMKeyProvider.java
@@ -378,7 +378,8 @@ public class AMKeyProvider implements KeyProvider {
         else
         {
         	privateKey = getPrivateKey(certAlias);
-        	mapKey.putIfAbsent(certAlias, privateKey);
+		if (privateKey != null)
+        		mapKey.putIfAbsent(certAlias, privateKey);
         }
 
         if (publicKey != null && privateKey != null) {


### PR DESCRIPTION
This PR fixes an issue that was introduced in 345a9e1, whereby an NPE will occur if the PrivateKey cannot be loaded.