### PR TITLE
IdRepoPluginsCache performance (lock on get)

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/idm/server/IdRepoPluginsCache.java
+++ b/openam-core/src/main/java/com/sun/identity/idm/server/IdRepoPluginsCache.java
@@ -38,6 +38,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -84,7 +85,7 @@ public class IdRepoPluginsCache implements ServiceListener {
     // The Map contains <orgName, MAP<name, IdRepo object>>
     private Map idrepoPlugins = new HashMap();
     // Needs to synchronized for get(), put() and clear()
-    private Map readonlyPlugins = new Hashtable();
+    private Map readonlyPlugins = new ConcurrentHashMap<>();
 
     private final ScheduledExecutorService scheduler;
     


### PR DESCRIPTION
```
 java.lang.Thread.State: BLOCKED (on object monitor)
        at java.util.Hashtable.get(Hashtable.java:363)
        - waiting to lock <0x00000003d7681a60> (a java.util.Hashtable)
        at com.sun.identity.idm.server.IdRepoPluginsCache.getIdRepoPlugins(IdRepoPluginsCache.java:194)
        at com.sun.identity.idm.server.IdServicesImpl.getAttributes(IdServicesImpl.java:630)
        at com.sun.identity.idm.server.IdCachedServicesImpl.getAttributes(IdCachedServicesImpl.java:440)
```