### PR TITLE
[#795] REST APIs after upgrade use Oldest API Version without header

### DIFF
--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/helpers/RestApiUpgradeHelper.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/helpers/RestApiUpgradeHelper.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2024 3A Systems, LLC
  */
 package org.forgerock.openam.upgrade.helpers;
 
@@ -27,7 +28,7 @@ import java.util.Collections;
 public class RestApiUpgradeHelper extends AbstractUpgradeHelper {
 
     private static final String DEFAULT_VERSION_ATTRIBUTE = "openam-rest-apis-default-version";
-    private static final String OLDEST_VERSION = "Oldest";
+    private static final String LATEST_VERSION = "Latest";
 
     /**
      * The constructor for RestApiUpgradeHelper is used to register the attributes which will be upgraded.
@@ -46,13 +47,12 @@ public class RestApiUpgradeHelper extends AbstractUpgradeHelper {
      */
     @Override
     public AttributeSchemaImpl upgradeAttribute(AttributeSchemaImpl newAttr) throws UpgradeException {
-        return updateDefaultValues(newAttr, Collections.singleton(OLDEST_VERSION));
+        return updateDefaultValues(newAttr, Collections.singleton(LATEST_VERSION));
     }
 
     /**
      * This implementation will always return <code>null</code> as there is currently no need to modify existing
      * schema attributes. This might change in the future in which case it should return the modified attribute.
-     *
      * {@inheritDoc}
      */
     @Override


### PR DESCRIPTION
see [#795]