### PR TITLE
Add integration test to the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,7 @@ jobs:
       - name: Upload docker image
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 1
           name: openam-image
           path: ${{ runner.temp }}/openam-tmp-image.tar
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21', '23' ]
-        os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
+        java: [ '8' ]
+        os: [ 'ubuntu-latest' ]
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
@@ -198,3 +198,75 @@ jobs:
           DS_DIRMGRPASSWD=passw0rd" > conf.file && java -jar openam-configurator-tool*.jar --file conf.file'
           sleep 35
           docker inspect --format="{{json .State.Health.Status}}" test | grep -q \"healthy\"
+
+  integration-test:
+    needs: [build-maven, build-docker]
+    runs-on: 'ubuntu-latest'
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - name: Download OpenAM war File
+        uses: actions/download-artifact@v4
+        with:
+          name: ubuntu-latest-8
+          path: openam-server/target/*.war
+        run: |
+          echo \
+          "FROM localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}
+          COPY openam-server/target/*.war /usr/local/tomcat/webapps/openam.war" > Dockerfile.tmp
+      - name: Run Integration Test
+        run: |
+          docker build -t localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-test -f ./Dockerfile.tmp .
+          
+          echo "starting containers"
+          docker run --rm -it -d --hostname opendj --name test-opendj --network test-openam localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-test
+          docker run --rm -it -d --hostname openam.example.org --name test-openam --network test-openam -p 8080:8080 test-openam-image
+          
+          echo "waiting for OpenDJ to be alive..."
+          timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" test-opendj | grep -q \"healthy\"; do sleep 10; done'
+          echo "waiting for OpenAM to be alive..."
+          timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" test-openam | grep -q \"healthy\"; do sleep 10; done'
+          
+          echo "OpenAM configuration"
+          docker exec -w '/usr/openam/ssoconfiguratortools' test-openam bash -c \
+          'echo "ACCEPT_LICENSES=true
+          SERVER_URL=http://openam.example.org:8080
+          DEPLOYMENT_URI=/$OPENAM_PATH
+          BASE_DIR=$OPENAM_DATA_DIR
+          locale=en_US
+          PLATFORM_LOCALE=en_US
+          AM_ENC_KEY=
+          ADMIN_PWD=ampassword
+          AMLDAPUSERPASSWD=password
+          COOKIE_DOMAIN=example.org
+          ACCEPT_LICENSES=true
+          DATA_STORE=dirServer
+          DIRECTORY_SSL=SIMPLE
+          DIRECTORY_SERVER=opendj
+          DIRECTORY_PORT=1389
+          DIRECTORY_ADMIN_PORT=4444
+          DIRECTORY_JMX_PORT=1689
+          ROOT_SUFFIX=dc=example,dc=com
+          DS_DIRMGRDN=cn=Directory Manager
+          DS_DIRMGRPASSWD=password
+          USERSTORE_TYPE=LDAPv3ForOpenDS
+          USERSTORE_SSL=SIMPLE
+          USERSTORE_HOST=opendj
+          USERSTORE_PORT=1389
+          USERSTORE_SUFFIX=dc=example,dc=com
+          USERSTORE_MGRDN=cn=Directory Manager
+          USERSTORE_PASSWD=password
+          " > conf.file && java -jar openam-configurator-tool*.jar --file conf.file'
+          
+          docker exec test-openam bash -c \
+          'curl \
+         --request POST \
+         --header "Content-Type: application/json" \
+         --header "X-OpenAM-Username: amadmin" \
+         --header "X-OpenAM-Password: ampassword" \
+         --data "{}" \
+         http://openam.example.org:8080/openam/json/authenticate | grep tokenId'
+          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,12 +94,15 @@ jobs:
           file: ./openam-distribution/openam-distribution-docker/Dockerfile
           build-args: |
             VERSION=${{ env.release_version }}
-          platforms: linux/amd64, linux/arm64, linux/ppc64le, linux/s390x
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Export image to file
-        run: docker save -o ${{ runner.temp }}/openam-tmp-image.tar localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}
+        shell: bash
+        run: |
+          docker image ls -a
+          docker save -o ${{ runner.temp }}/openam-tmp-image.tar localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}
       - name: Docker test
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,10 +263,10 @@ jobs:
           
           docker exec test-openam bash -c \
           'curl \
-         --request POST \
-         --header "Content-Type: application/json" \
-         --header "X-OpenAM-Username: amadmin" \
-         --header "X-OpenAM-Password: ampassword" \
-         --data "{}" \
-         http://openam.example.org:8080/openam/json/authenticate | grep tokenId'
+           --request POST \
+           --header "Content-Type: application/json" \
+           --header "X-OpenAM-Username: amadmin" \
+           --header "X-OpenAM-Password: ampassword" \
+           --data "{}" \
+           http://openam.example.org:8080/openam/json/authenticate | grep tokenId'
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,9 +98,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs:
-            - type=docker,dest=${{ runner.temp }}/${GITHUB_REPOSITORY,,}-image.tar
-            - type=registry
+          outputs: type=docker,dest=${{ runner.temp }}/${GITHUB_REPOSITORY,,}-image.tar
       - name: Docker test
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,12 +245,12 @@ jobs:
         run: |
           echo \
           "FROM localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}
-          COPY ${{ runner.temp }}/*.war /usr/local/tomcat/webapps/openam.war" > Dockerfile.tmp
-          cat Dockerfile.tmp
+          COPY ${{ runner.temp }}/openam-server/target/*.war /usr/local/tomcat/webapps/openam.war" > ${{ runner.temp }}/Dockerfile.tmp
+          cat ${{ runner.temp }}/Dockerfile.tmp
       - name: Run Integration Test
         shell: bash
         run: |
-          docker build -t localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-test -f ./Dockerfile.tmp .
+          docker build -t localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-test -f ${{ runner.temp }}/Dockerfile.tmp ${{ runner.temp }}
           
           echo "starting containers"
           docker run --rm -it -d --hostname opendj --name test-opendj --network test-openam localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,7 @@ jobs:
         run: |
           echo \
           "FROM localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}
-          COPY ${{ runner.temp }}/openam-server/target/*.war /usr/local/tomcat/webapps/openam.war" > ${{ runner.temp }}/Dockerfile.tmp
+          COPY ./openam-server/target/*.war /usr/local/tomcat/webapps/openam.war" > ${{ runner.temp }}/Dockerfile.tmp
           cat ${{ runner.temp }}/Dockerfile.tmp
       - name: Run Integration Test
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ jobs:
       - name: Export image to file
         shell: bash
         run: |
+          docker pull localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}
           docker image ls -a
           docker save -o ${{ runner.temp }}/openam-tmp-image.tar localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}
       - name: Docker test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=${{ runner.temp }}/openam-tmp-image.tar
+      - name: Export image to file
+        run: docker save -o ${{ runner.temp }}/openam-tmp-image.tar localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}
       - name: Docker test
         shell: bash
         run: |
@@ -127,7 +128,7 @@ jobs:
           DS_DIRMGRPASSWD=passw0rd" > conf.file && java -jar openam-configurator-tool*.jar --file conf.file'
           sleep 35
           docker inspect --format="{{json .State.Health.Status}}" test | grep -q \"healthy\"
-      - name: Upload artifact
+      - name: Upload docker image
         uses: actions/upload-artifact@v4
         with:
           name: openam-image
@@ -241,6 +242,7 @@ jobs:
           "FROM localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}
           COPY openam-server/target/*.war /usr/local/tomcat/webapps/openam.war" > Dockerfile.tmp
       - name: Run Integration Test
+        shell: bash
         run: |
           docker build -t localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-test -f ./Dockerfile.tmp .
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set Integration Test Environment
       if: matrix.os == 'ubuntu-latest'
       run:  | 
-        echo "MAVEN_PROFILE_FLAG=-P \!man-pages -DskipTests=true" >> $GITHUB_OUTPUT 
+        echo "MAVEN_PROFILE_FLAG=-P \!man-pages -DskipTests=true -Dcargo.maven.skip=true" >> $GITHUB_OUTPUT 
         echo "MAVEN_VERIFY_STAGE=verify" >> $GITHUB_OUTPUT
         echo "127.0.0.1 openam.local" | sudo tee -a /etc/hosts
       id: maven-profile-flag
@@ -87,7 +87,7 @@ jobs:
         with:
           driver-opts: network=host
       - name: Build image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         continue-on-error: true
         with:
           context: ./openam-distribution/openam-distribution-docker
@@ -98,6 +98,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs:
+            - type=docker,dest=${{ runner.temp }}/${GITHUB_REPOSITORY,,}-image.tar
+            - type=registry
       - name: Docker test
         shell: bash
         run: |
@@ -126,6 +129,12 @@ jobs:
           DS_DIRMGRPASSWD=passw0rd" > conf.file && java -jar openam-configurator-tool*.jar --file conf.file'
           sleep 35
           docker inspect --format="{{json .State.Health.Status}}" test | grep -q \"healthy\"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openam-image
+          path: ${{ runner.temp }}/${GITHUB_REPOSITORY,,}-image.tar
+
   build-docker-alpine:
     runs-on: 'ubuntu-latest'
     services:
@@ -218,6 +227,16 @@ jobs:
         with:
           name: ubuntu-latest-8
           path: openam-server/target/*.war
+      - name: Download OpenAM Docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: openam-image
+          path: ${{ runner.temp }}/${GITHUB_REPOSITORY,,}-image.tar
+      - name: Load image
+        run: |
+          docker load --input ${{ runner.temp }}/${GITHUB_REPOSITORY,,}-image.tar
+          docker image ls -a
+
       - name: Build test Docker image
         run: |
           echo \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,7 +252,7 @@ jobs:
         shell: bash
         run: |
           docker build -t localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-test -f ${{ runner.temp }}/Dockerfile.tmp ${{ runner.temp }}
-          
+          docker create network test-openam
           echo "starting containers"
           docker run --rm -it -d --hostname opendj --name test-opendj --network test-openam localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-test
           docker run --rm -it -d --hostname openam.example.org --name test-openam --network test-openam -p 8080:8080 test-openam-image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,7 +252,7 @@ jobs:
         shell: bash
         run: |
           docker build -t localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-test -f ${{ runner.temp }}/Dockerfile.tmp ${{ runner.temp }}
-          docker create network test-openam
+          docker network create test-openam
           echo "starting containers"
           docker run --rm -it -d --hostname opendj --name test-opendj --network test-openam localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-test
           docker run --rm -it -d --hostname openam.example.org --name test-openam --network test-openam -p 8080:8080 test-openam-image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,14 +229,15 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ubuntu-latest-8
-          path: openam-server/target/*.war
+          path: ${{ runner.temp }}
       - name: Download OpenAM Docker image
         uses: actions/download-artifact@v4
         with:
           name: openam-image
-          path: ${{ runner.temp }}/openam-tmp-image.tar
+          path: ${{ runner.temp }}
       - name: Load image
         run: |
+          ls ${{ runner.temp }}
           docker load --input ${{ runner.temp }}/openam-tmp-image.tar
           docker image ls -a
 
@@ -244,7 +245,8 @@ jobs:
         run: |
           echo \
           "FROM localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}
-          COPY openam-server/target/*.war /usr/local/tomcat/webapps/openam.war" > Dockerfile.tmp
+          COPY ${{ runner.temp }}/*.war /usr/local/tomcat/webapps/openam.war" > Dockerfile.tmp
+          cat Dockerfile.tmp
       - name: Run Integration Test
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,16 +61,20 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
+    outputs:
+      release_version: ${{ steps.get_release_version.outputs.release_version }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
       - name: Get latest release version
+        id: get_release_version
         shell: bash
         run:   |
           export git_version_last="$(curl -i -o - --silent https://api.github.com/repos/OpenIdentityPlatform/OpenAM/releases/latest | grep -m1 "\"name\"" | cut -d\" -f4)" ; echo "last release: $git_version_last"
           echo "release_version=$git_version_last" >> $GITHUB_ENV
+          echo "release_version=$git_version_last" >> $GITHUB_OUTPUT
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -224,8 +228,8 @@ jobs:
       - name: Get latest release version
         shell: bash
         run:   |
-          export git_version_last="$(curl -i -o - --silent https://api.github.com/repos/OpenIdentityPlatform/OpenAM/releases/latest | grep -m1 "\"name\"" | cut -d\" -f4)" ; echo "last release: $git_version_last"
-          echo "release_version=$git_version_last" >> $GITHUB_ENV
+          echo "last release: ${{needs.build-docker.outputs.release_version}}"
+          echo "release_version=${{needs.build-docker.outputs.release_version}}" >> $GITHUB_ENV
       - name: Download OpenAM war File
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,6 +213,7 @@ jobs:
         with:
           name: ubuntu-latest-8
           path: openam-server/target/*.war
+      - name: Build test Docker image
         run: |
           echo \
           "FROM localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set Integration Test Environment
       if: matrix.os == 'ubuntu-latest'
       run:  | 
-        echo "MAVEN_PROFILE_FLAG=-P integration-test" >> $GITHUB_OUTPUT 
+        echo "MAVEN_PROFILE_FLAG=-P \!man-pages -DskipTests=true" >> $GITHUB_OUTPUT 
         echo "MAVEN_VERIFY_STAGE=verify" >> $GITHUB_OUTPUT
         echo "127.0.0.1 openam.local" | sudo tee -a /etc/hosts
       id: maven-profile-flag
@@ -208,6 +208,11 @@ jobs:
         ports:
           - 5000:5000
     steps:
+      - name: Get latest release version
+        shell: bash
+        run:   |
+          export git_version_last="$(curl -i -o - --silent https://api.github.com/repos/OpenIdentityPlatform/OpenAM/releases/latest | grep -m1 "\"name\"" | cut -d\" -f4)" ; echo "last release: $git_version_last"
+          echo "release_version=$git_version_last" >> $GITHUB_ENV
       - name: Download OpenAM war File
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=${{ runner.temp }}/${GITHUB_REPOSITORY,,}-image.tar
+          outputs: type=docker,dest=${{ runner.temp }}/openam-tmp-image.tar
       - name: Docker test
         shell: bash
         run: |
@@ -131,7 +131,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: openam-image
-          path: ${{ runner.temp }}/${GITHUB_REPOSITORY,,}-image.tar
+          path: ${{ runner.temp }}/openam-tmp-image.tar
 
   build-docker-alpine:
     runs-on: 'ubuntu-latest'
@@ -229,10 +229,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: openam-image
-          path: ${{ runner.temp }}/${GITHUB_REPOSITORY,,}-image.tar
+          path: ${{ runner.temp }}/openam-tmp-image.tar
       - name: Load image
         run: |
-          docker load --input ${{ runner.temp }}/${GITHUB_REPOSITORY,,}-image.tar
+          docker load --input ${{ runner.temp }}/openam-tmp-image.tar
           docker image ls -a
 
       - name: Build test Docker image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [ '8' ]
-        os: [ 'ubuntu-latest' ]
+        java: [ '8', '11', '17', '21', '23' ]
+        os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
@@ -31,8 +31,8 @@ jobs:
          restore-keys: ${{ runner.os }}-m2-repository
     - name: Set Integration Test Environment
       if: matrix.os == 'ubuntu-latest'
-      run:  | 
-        echo "MAVEN_PROFILE_FLAG=-P \!man-pages -DskipTests=true -Dcargo.maven.skip=true" >> $GITHUB_OUTPUT 
+      run:  |
+        echo "MAVEN_PROFILE_FLAG=-P integration-test" >> $GITHUB_OUTPUT 
         echo "MAVEN_VERIFY_STAGE=verify" >> $GITHUB_OUTPUT
         echo "127.0.0.1 openam.local" | sudo tee -a /etc/hosts
       id: maven-profile-flag
@@ -94,7 +94,7 @@ jobs:
           file: ./openam-distribution/openam-distribution-docker/Dockerfile
           build-args: |
             VERSION=${{ env.release_version }}
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64, linux/ppc64le, linux/s390x
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,8 +254,8 @@ jobs:
           docker build -t localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-test -f ${{ runner.temp }}/Dockerfile.tmp ${{ runner.temp }}
           docker network create test-openam
           echo "starting containers"
-          docker run --rm -it -d --hostname opendj --name test-opendj --network test-openam localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-test
-          docker run --rm -it -d --hostname openam.example.org --name test-openam --network test-openam -p 8080:8080 test-openam-image
+          docker run --rm -it -d --hostname opendj --name test-opendj --network test-openam openidentityplatform/opendj
+          docker run --rm -it -d --hostname openam.example.org --name test-openam --network test-openam -p 8080:8080 localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-test
           
           echo "waiting for OpenDJ to be alive..."
           timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" test-opendj | grep -q \"healthy\"; do sleep 10; done'


### PR DESCRIPTION
The test creates a Docker container with the WAR file built from the latest sources, then runs the container. It also starts another Docker container with OpenDJ and performs the installation process. If the installation is successful, it tests authentication via the API.

This PR's action should be executed after merging #861