### PR TITLE
Migrate tests from using fest-assert to AssertJ

### DIFF
--- a/openam-audit/openam-audit-context/pom.xml
+++ b/openam-audit/openam-audit-context/pom.xml
@@ -54,10 +54,6 @@
             <artifactId>core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-        </dependency>
-        <dependency>
 		  <groupId>org.mockito</groupId>
 		  <artifactId>mockito-core</artifactId>
 		  <scope>test</scope>

--- a/openam-audit/openam-audit-context/src/test/java/org/forgerock/openam/audit/AuditContextFilterTest.java
+++ b/openam-audit/openam-audit-context/src/test/java/org/forgerock/openam/audit/AuditContextFilterTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.audit;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 

--- a/openam-authentication/openam-auth-oidc/pom.xml
+++ b/openam-authentication/openam-auth-oidc/pom.xml
@@ -54,11 +54,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>

--- a/openam-authentication/openam-auth-oidc/src/test/java/org/forgerock/openam/authentication/modules/oidc/JwtAttributeMapperTest.java
+++ b/openam-authentication/openam-auth-oidc/src/test/java/org/forgerock/openam/authentication/modules/oidc/JwtAttributeMapperTest.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JwtAttributeMapperTest {
     private static final String EMAIL = "email";

--- a/openam-authentication/openam-auth-oidc/src/test/java/org/forgerock/openam/authentication/modules/oidc/OpenIdConnectConfigTest.java
+++ b/openam-authentication/openam-auth-oidc/src/test/java/org/forgerock/openam/authentication/modules/oidc/OpenIdConnectConfigTest.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.openam.utils.CollectionUtils.*;
 
 

--- a/openam-authentication/openam-auth-scripted/pom.xml
+++ b/openam-authentication/openam-auth-scripted/pom.xml
@@ -56,11 +56,6 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
 
     </dependencies>
 </project>

--- a/openam-console/pom.xml
+++ b/openam-console/pom.xml
@@ -182,11 +182,6 @@
             <artifactId>openam-oauth2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/openam-console/src/test/java/com/sun/identity/console/base/AMPropertySheetTest.java
+++ b/openam-console/src/test/java/com/sun/identity/console/base/AMPropertySheetTest.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 

--- a/openam-console/src/test/java/com/sun/identity/console/base/model/AMAdminUtilsToSetTest.java
+++ b/openam-console/src/test/java/com/sun/identity/console/base/model/AMAdminUtilsToSetTest.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -83,7 +83,7 @@ public class AMAdminUtilsToSetTest {
         assertThat(result).isNotNull()
                           .hasSize(2)
                           .contains("aaa", "ccc")
-                          .excludes("");
+                          .doesNotContain("");
     }
 
     @Test

--- a/openam-core/pom.xml
+++ b/openam-core/pom.xml
@@ -396,10 +396,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-             <groupId>org.easytesting</groupId>
-             <artifactId>fest-assert</artifactId>
-         </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>

--- a/openam-core/src/test/java/com/iplanet/dpro/session/operations/ClientSdkSessionOperationStrategyTest.java
+++ b/openam-core/src/test/java/com/iplanet/dpro/session/operations/ClientSdkSessionOperationStrategyTest.java
@@ -15,7 +15,7 @@
  */
 package com.iplanet.dpro.session.operations;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.testng.annotations.Test;

--- a/openam-core/src/test/java/com/iplanet/dpro/session/operations/ServerSessionOperationStrategyTest.java
+++ b/openam-core/src/test/java/com/iplanet/dpro/session/operations/ServerSessionOperationStrategyTest.java
@@ -15,7 +15,7 @@
  */
 package com.iplanet.dpro.session.operations;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;

--- a/openam-core/src/test/java/com/iplanet/dpro/session/operations/strategies/ClientSdkOperationsTest.java
+++ b/openam-core/src/test/java/com/iplanet/dpro/session/operations/strategies/ClientSdkOperationsTest.java
@@ -15,7 +15,7 @@
  */
 package com.iplanet.dpro.session.operations.strategies;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;

--- a/openam-core/src/test/java/com/iplanet/dpro/session/service/SessionServerConfigTest.java
+++ b/openam-core/src/test/java/com/iplanet/dpro/session/service/SessionServerConfigTest.java
@@ -11,7 +11,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;

--- a/openam-core/src/test/java/com/iplanet/dpro/session/service/WebtopNamingSiteUtilsTest.java
+++ b/openam-core/src/test/java/com/iplanet/dpro/session/service/WebtopNamingSiteUtilsTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 import java.net.URL;
 import java.util.Set;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;

--- a/openam-core/src/test/java/com/iplanet/dpro/session/service/cluster/MultiServerClusterMonitorTest.java
+++ b/openam-core/src/test/java/com/iplanet/dpro/session/service/cluster/MultiServerClusterMonitorTest.java
@@ -16,7 +16,7 @@
 
 package com.iplanet.dpro.session.service.cluster;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;

--- a/openam-core/src/test/java/com/iplanet/dpro/session/utils/SessionInfoFactoryTest.java
+++ b/openam-core/src/test/java/com/iplanet/dpro/session/utils/SessionInfoFactoryTest.java
@@ -16,7 +16,7 @@
 
 package com.iplanet.dpro.session.utils;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;

--- a/openam-core/src/test/java/com/sun/identity/entitlement/EntitlementCombinerTest.java
+++ b/openam-core/src/test/java/com/sun/identity/entitlement/EntitlementCombinerTest.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 import static java.util.Collections.EMPTY_MAP;
 import static java.util.Collections.EMPTY_SET;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/openam-core/src/test/java/com/sun/identity/entitlement/PrefixResourceNameTest.java
+++ b/openam-core/src/test/java/com/sun/identity/entitlement/PrefixResourceNameTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 
 import java.util.HashMap;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Exercises the behaviour of {@link PrefixResourceName}.

--- a/openam-core/src/test/java/com/sun/identity/entitlement/SubtreeWildcardTest.java
+++ b/openam-core/src/test/java/com/sun/identity/entitlement/SubtreeWildcardTest.java
@@ -19,7 +19,7 @@ package com.sun.identity.entitlement;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**

--- a/openam-core/src/test/java/com/sun/identity/entitlement/URLResourceNameTest.java
+++ b/openam-core/src/test/java/com/sun/identity/entitlement/URLResourceNameTest.java
@@ -15,11 +15,10 @@
  */
 package com.sun.identity.entitlement;
 
-import org.fest.assertions.ComparisonFailureFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit test for URLResourceName.
@@ -39,7 +38,7 @@ public class URLResourceNameTest {
      * Tests that the normalisation process adheres to the expected rules.
      */
     @Test
-    public void verifyPortHandling() {
+    public void verifyPortHandling() throws Exception {
         // Previous ports are maintained.
         assertNormalisation("http://www.example.com:80/hello", "http://www.example.com:80/hello");
         assertNormalisation("http://www.example.com:12345/hello", "http://www.example.com:12345/hello");
@@ -69,13 +68,7 @@ public class URLResourceNameTest {
      * @param treatedResource
      *         The expected resource after it's been normalised.
      */
-    private void assertNormalisation(String untreatedResource, String treatedResource) {
-        try {
-            assertThat(resourceName.canonicalize(untreatedResource)).isEqualTo(treatedResource);
-        } catch (Exception e) {
-            String message = "Normalisation failed: " + e.getMessage();
-            throw ComparisonFailureFactory.comparisonFailure(message, treatedResource, "");
-        }
+    private void assertNormalisation(String untreatedResource, String treatedResource) throws Exception {
+        assertThat(resourceName.canonicalize(untreatedResource)).isEqualTo(treatedResource);
     }
-
 }

--- a/openam-core/src/test/java/com/sun/identity/idm/AMIdentityTest.java
+++ b/openam-core/src/test/java/com/sun/identity/idm/AMIdentityTest.java
@@ -15,7 +15,7 @@
  */
 package com.sun.identity.idm;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import com.iplanet.sso.SSOToken;

--- a/openam-core/src/test/java/com/sun/identity/idm/IdRepoExceptionTest.java
+++ b/openam-core/src/test/java/com/sun/identity/idm/IdRepoExceptionTest.java
@@ -15,7 +15,7 @@
 */
 package com.sun.identity.idm;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;

--- a/openam-core/src/test/java/com/sun/identity/idm/common/IdRepoUtilsTest.java
+++ b/openam-core/src/test/java/com/sun/identity/idm/common/IdRepoUtilsTest.java
@@ -18,8 +18,8 @@ package com.sun.identity.idm.common;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import static org.fest.assertions.Assertions.*;
-import static org.forgerock.openam.utils.CollectionUtils.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.openam.utils.CollectionUtils.asSet;
 import org.testng.annotations.Test;
 
 public class IdRepoUtilsTest {
@@ -33,7 +33,7 @@ public class IdRepoUtilsTest {
         values.put("aunicodepwd", asSet("test4"));
         values.put("unicodepwd2", asSet("test5"));
         values.put("unicodepwd", asSet("test6"));
-        Map<String, ?> result = IdRepoUtils.getAttrMapWithoutPasswordAttrs(values, null);
+        Map result = IdRepoUtils.getAttrMapWithoutPasswordAttrs(values, null);
         assertThat(result.values()).containsOnly(asSet("test1"), asSet("test2"), asSet("test4"), asSet("test5"),
                 "xxx...");
     }
@@ -47,7 +47,7 @@ public class IdRepoUtilsTest {
         values.put("UnIcOdEpWd", asSet("test4"));
         values.put("unicodePwd", asSet("test5"));
         values.put("unicodepwd", asSet("test6"));
-        Map<String, ?> result = IdRepoUtils.getAttrMapWithoutPasswordAttrs(values, null);
+        Map result = IdRepoUtils.getAttrMapWithoutPasswordAttrs(values, null);
         assertThat(result.values()).containsOnly("xxx...");
     }
 
@@ -60,7 +60,7 @@ public class IdRepoUtilsTest {
         values.put("unicodepwd", asSet("test4"));
         values.put("hellp", asSet("test5"));
         values.put("worlt", asSet("test6"));
-        Map<String, ?> result = IdRepoUtils.getAttrMapWithoutPasswordAttrs(values, asSet("HELLO", "WORLD"));
+        Map result = IdRepoUtils.getAttrMapWithoutPasswordAttrs(values, asSet("HELLO", "WORLD"));
         assertThat(result.values()).containsOnly(asSet("test5"), asSet("test6"), "xxx...");
     }
 }

--- a/openam-core/src/test/java/com/sun/identity/log/service/AgentLogParserTest.java
+++ b/openam-core/src/test/java/com/sun/identity/log/service/AgentLogParserTest.java
@@ -15,7 +15,7 @@
  */
 package com.sun.identity.log.service;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.forgerock.audit.events.AccessAuditEventBuilder.ResponseStatus;
 import org.testng.annotations.BeforeMethod;

--- a/openam-core/src/test/java/com/sun/identity/policy/plugins/PrefixResourceNameTest.java
+++ b/openam-core/src/test/java/com/sun/identity/policy/plugins/PrefixResourceNameTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 
 import java.util.HashMap;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Exercises the behaviour of {@link PrefixResourceName}.

--- a/openam-core/src/test/java/com/sun/identity/policy/plugins/URLResourceNameTest.java
+++ b/openam-core/src/test/java/com/sun/identity/policy/plugins/URLResourceNameTest.java
@@ -15,11 +15,10 @@
  */
 package com.sun.identity.policy.plugins;
 
-import org.fest.assertions.ComparisonFailureFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit test for URLResourceName.
@@ -39,7 +38,7 @@ public class URLResourceNameTest {
      * Tests that the normalisation process adheres to the expected rules.
      */
     @Test
-    public void verifyPortHandling() {
+    public void verifyPortHandling() throws Exception {
         // Previous ports are maintained.
         assertNormalisation("http://www.example.com:80/hello", "http://www.example.com:80/hello");
         assertNormalisation("http://www.example.com:12345/hello", "http://www.example.com:12345/hello");
@@ -69,13 +68,7 @@ public class URLResourceNameTest {
      * @param treatedResource
      *         The expected resource after it's been normalised.
      */
-    private void assertNormalisation(String untreatedResource, String treatedResource) {
-        try {
-            assertThat(resourceName.canonicalize(untreatedResource)).isEqualTo(treatedResource);
-        } catch (Exception e) {
-            String message = "Normalisation failed: " + e.getMessage();
-            throw ComparisonFailureFactory.comparisonFailure(message, treatedResource, "");
-        }
+    private void assertNormalisation(String untreatedResource, String treatedResource) throws Exception {
+        assertThat(resourceName.canonicalize(untreatedResource)).isEqualTo(treatedResource);
     }
-
 }

--- a/openam-core/src/test/java/org/forgerock/openam/auditors/SMSAuditorTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/auditors/SMSAuditorTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.auditors;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.testng.Reporter;
 import org.testng.annotations.DataProvider;

--- a/openam-core/src/test/java/org/forgerock/openam/authentication/callbacks/helpers/PollingWaitSpamCheckerTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/authentication/callbacks/helpers/PollingWaitSpamCheckerTest.java
@@ -17,10 +17,11 @@ package org.forgerock.openam.authentication.callbacks.helpers;
 
 import java.util.concurrent.TimeUnit;
 
-import org.fest.assertions.Assertions;
 import org.forgerock.openam.utils.TimeTravelUtil;
 import org.forgerock.openam.utils.TimeTravelUtil.FastForwardTimeService;
 import org.forgerock.util.time.TimeService;
+
+import org.assertj.core.api.Assertions;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;

--- a/openam-core/src/test/java/org/forgerock/openam/cts/CTSPersistentStoreImplTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/CTSPersistentStoreImplTest.java
@@ -23,7 +23,7 @@ import org.forgerock.util.Options;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;

--- a/openam-core/src/test/java/org/forgerock/openam/cts/TokenTestUtils.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/TokenTestUtils.java
@@ -26,7 +26,7 @@ import java.text.MessageFormat;
 import java.util.Calendar;
 import java.util.TimeZone;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.openam.utils.Time.*;
 
 /**

--- a/openam-core/src/test/java/org/forgerock/openam/cts/adapters/JavaBeanAdapterTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/adapters/JavaBeanAdapterTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.cts.adapters;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;

--- a/openam-core/src/test/java/org/forgerock/openam/cts/adapters/SAMLAdapterTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/adapters/SAMLAdapterTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.cts.adapters;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.openam.utils.Time.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;

--- a/openam-core/src/test/java/org/forgerock/openam/cts/adapters/SessionAdapterTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/adapters/SessionAdapterTest.java
@@ -17,7 +17,7 @@ package org.forgerock.openam.cts.adapters;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.openam.utils.Time.currentTimeMillis;
 import static org.forgerock.openam.utils.Time.getCalendarInstance;
 import static org.mockito.BDDMockito.given;

--- a/openam-core/src/test/java/org/forgerock/openam/cts/api/fields/CoreTokenFieldTypesTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/api/fields/CoreTokenFieldTypesTest.java
@@ -18,8 +18,9 @@ package org.forgerock.openam.cts.api.fields;
 
 import static org.forgerock.openam.utils.Time.*;
 
-import org.fest.assertions.Assertions;
-import org.fest.assertions.Condition;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+
 import org.forgerock.openam.cts.api.tokens.Token;
 import org.forgerock.openam.cts.exceptions.CoreTokenException;
 import org.forgerock.openam.tokens.CoreTokenField;
@@ -86,10 +87,9 @@ public class CoreTokenFieldTypesTest {
                 continue;
             }
 
-            Assertions.assertThat(field).satisfies(new Condition<Object>("has valid type") {
+            Assertions.assertThat(field).is(new Condition<CoreTokenField>("has valid type") {
                 @Override
-                public boolean matches(Object t) {
-                    CoreTokenField obj = (CoreTokenField) t;
+                public boolean matches(CoreTokenField obj) {
                     return CoreTokenFieldTypes.isByteArray(obj) || CoreTokenFieldTypes.isCalendar(obj)
                             || CoreTokenFieldTypes.isInteger(obj) || CoreTokenFieldTypes.isString(obj);
                 }

--- a/openam-core/src/test/java/org/forgerock/openam/cts/exceptions/CoreTokenExceptionTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/exceptions/CoreTokenExceptionTest.java
@@ -17,7 +17,7 @@ package org.forgerock.openam.cts.exceptions;
 
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CoreTokenExceptionTest {
     @Test

--- a/openam-core/src/test/java/org/forgerock/openam/cts/impl/CoreTokenAdapterTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/impl/CoreTokenAdapterTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.cts.impl;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.*;
 
 import java.util.ArrayList;

--- a/openam-core/src/test/java/org/forgerock/openam/cts/impl/LDAPConfigTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/impl/LDAPConfigTest.java
@@ -24,7 +24,7 @@ import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.*;
 import static org.testng.Assert.assertEquals;

--- a/openam-core/src/test/java/org/forgerock/openam/cts/impl/LdapAdapterTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/impl/LdapAdapterTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.cts.impl;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.openam.cts.api.CTSOptions.OPTIMISTIC_CONCURRENCY_CHECK_OPTION;
 import static org.forgerock.openam.cts.api.CTSOptions.PRE_DELETE_READ_OPTION;
 import static org.forgerock.openam.utils.CollectionUtils.asSet;

--- a/openam-core/src/test/java/org/forgerock/openam/cts/impl/query/PartialTokenTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/impl/query/PartialTokenTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 import java.util.Collections;
 import java.util.Map;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class PartialTokenTest {

--- a/openam-core/src/test/java/org/forgerock/openam/cts/impl/query/worker/queries/CTSWorkerBaseQueryTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/impl/query/worker/queries/CTSWorkerBaseQueryTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.cts.impl.query.worker.queries;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.*;
 
 import java.util.Arrays;

--- a/openam-core/src/test/java/org/forgerock/openam/cts/impl/queue/AsyncResultHandlerTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/impl/queue/AsyncResultHandlerTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.cts.impl.queue;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.concurrent.ArrayBlockingQueue;

--- a/openam-core/src/test/java/org/forgerock/openam/cts/impl/queue/QueueSelectorTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/impl/queue/QueueSelectorTest.java
@@ -18,7 +18,7 @@ package org.forgerock.openam.cts.impl.queue;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class QueueSelectorTest {
 

--- a/openam-core/src/test/java/org/forgerock/openam/cts/impl/queue/config/CTSQueueConfigurationTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/impl/queue/config/CTSQueueConfigurationTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.cts.impl.queue.config;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.anyObject;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;

--- a/openam-core/src/test/java/org/forgerock/openam/cts/monitoring/impl/persistence/CtsPersistenceOperationsMonitorTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/monitoring/impl/persistence/CtsPersistenceOperationsMonitorTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;

--- a/openam-core/src/test/java/org/forgerock/openam/cts/utils/blob/TokenBlobStrategyTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/utils/blob/TokenBlobStrategyTest.java
@@ -22,8 +22,7 @@ import org.testng.annotations.Test;
 
 import java.util.Arrays;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.Fail.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -114,9 +113,7 @@ public class TokenBlobStrategyTest {
         // Then
         Object dataRef = data;
         Object captorRef = captor.getValue();
-        if (dataRef == captorRef) { // Verify the references are different (the contents will be the same)
-            fail();
-        }
+        assertThat(dataRef).isNotSameAs(captorRef);
     }
 
     @Test

--- a/openam-core/src/test/java/org/forgerock/openam/cts/utils/blob/TokenBlobUtilsTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/utils/blob/TokenBlobUtilsTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 
 import java.io.UnsupportedEncodingException;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.given;

--- a/openam-core/src/test/java/org/forgerock/openam/cts/utils/blob/TokenStrategyFactoryTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/utils/blob/TokenStrategyFactoryTest.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 

--- a/openam-core/src/test/java/org/forgerock/openam/cts/utils/blob/strategies/AttributeCompressionStrategyTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/utils/blob/strategies/AttributeCompressionStrategyTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 
 import java.io.UnsupportedEncodingException;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 public class AttributeCompressionStrategyTest {

--- a/openam-core/src/test/java/org/forgerock/openam/cts/utils/blob/strategies/CompressionStrategyTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/utils/blob/strategies/CompressionStrategyTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.openam.utils.Time.*;
 
 public class CompressionStrategyTest {

--- a/openam-core/src/test/java/org/forgerock/openam/cts/utils/blob/strategies/encryption/EncryptDecryptActionTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/utils/blob/strategies/encryption/EncryptDecryptActionTest.java
@@ -17,7 +17,7 @@ package org.forgerock.openam.cts.utils.blob.strategies.encryption;
 
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class EncryptDecryptActionTest {
     @Test

--- a/openam-core/src/test/java/org/forgerock/openam/cts/worker/process/TokenDeletionTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/worker/process/TokenDeletionTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.cts.worker.process;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.*;
 
 import java.util.Arrays;

--- a/openam-core/src/test/java/org/forgerock/openam/entitlement/service/ApplicationQueryFilterVisitorTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/entitlement/service/ApplicationQueryFilterVisitorTest.java
@@ -25,8 +25,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.fest.assertions.Assertions;
 import org.forgerock.util.query.QueryFilter;
+import org.assertj.core.api.Assertions;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 

--- a/openam-core/src/test/java/org/forgerock/openam/services/baseurl/ExtensionBaseURLProviderTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/services/baseurl/ExtensionBaseURLProviderTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.services.baseurl;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import javax.servlet.http.HttpServletRequest;

--- a/openam-core/src/test/java/org/forgerock/openam/services/baseurl/FixedBaseURLProviderTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/services/baseurl/FixedBaseURLProviderTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.services.baseurl;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import javax.servlet.http.HttpServletRequest;

--- a/openam-core/src/test/java/org/forgerock/openam/services/baseurl/ForwardedHeaderBaseURLProviderTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/services/baseurl/ForwardedHeaderBaseURLProviderTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.services.baseurl;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;

--- a/openam-core/src/test/java/org/forgerock/openam/services/baseurl/RequestValuesBaseURLProviderTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/services/baseurl/RequestValuesBaseURLProviderTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.services.baseurl;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;

--- a/openam-core/src/test/java/org/forgerock/openam/services/baseurl/XForwardedHeadersBaseURLProviderTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/services/baseurl/XForwardedHeadersBaseURLProviderTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.services.baseurl;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;

--- a/openam-core/src/test/java/org/forgerock/openam/session/SessionCacheTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/session/SessionCacheTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.session;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.Mockito.*;

--- a/openam-core/src/test/java/org/forgerock/openam/session/service/access/SessionPersistenceStoreTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/session/service/access/SessionPersistenceStoreTest.java
@@ -19,7 +19,6 @@ package org.forgerock.openam.session.service.access;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.*;
 
-import org.fest.util.Collections;
 import org.forgerock.guice.core.GuiceModules;
 import org.forgerock.guice.core.GuiceTestCase;
 import org.forgerock.openam.cts.CTSPersistentStore;
@@ -28,6 +27,7 @@ import org.forgerock.openam.cts.api.filter.TokenFilter;
 import org.forgerock.openam.cts.api.tokens.Token;
 import org.forgerock.openam.cts.api.tokens.TokenIdFactory;
 import org.forgerock.openam.session.service.access.persistence.SessionPersistenceStore;
+import org.forgerock.openam.utils.CollectionUtils;
 import org.forgerock.openam.dpro.session.PartialSessionFactory;
 import org.forgerock.openam.identity.idm.IdentityUtils;
 import org.mockito.Mock;
@@ -100,14 +100,14 @@ public class SessionPersistenceStoreTest extends GuiceTestCase {
 
     @Test
     public void recoversSessionByHandle() throws Exception {
-        given(mockCoreTokenService.query(any(TokenFilter.class))).willReturn(Collections.list(mockToken));
+        given(mockCoreTokenService.query(any(TokenFilter.class))).willReturn(CollectionUtils.asList(mockToken));
 
         assertThat(sessionPersistenceStore.recoverSessionByHandle(HANDLE)).isEqualTo(mockSession);
     }
 
     @Test
     public void failsRecoverSessionByHandleWithNonUniqueMatch() throws Exception {
-        given(mockCoreTokenService.query(any(TokenFilter.class))).willReturn(Collections.list(mock(Token.class), mockToken));
+        given(mockCoreTokenService.query(any(TokenFilter.class))).willReturn(CollectionUtils.asList(mock(Token.class), mockToken));
 
         assertThat(sessionPersistenceStore.recoverSessionByHandle(HANDLE)).isNull();
     }

--- a/openam-core/src/test/java/org/forgerock/openam/session/stateless/StatelessConfigTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/session/stateless/StatelessConfigTest.java
@@ -20,7 +20,7 @@ import com.iplanet.am.util.SystemPropertiesWrapper;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;

--- a/openam-core/src/test/java/org/forgerock/openam/session/stateless/cache/StatelessJWTCacheTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/session/stateless/cache/StatelessJWTCacheTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.session.stateless.cache;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.anyString;
 import static org.mockito.BDDMockito.*;

--- a/openam-core/src/test/java/org/forgerock/openam/sm/SMSConfigurationFactoryTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/sm/SMSConfigurationFactoryTest.java
@@ -22,7 +22,7 @@ import org.forgerock.openam.sm.exceptions.ServerConfigurationNotFound;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.Matchers.any;

--- a/openam-core/src/test/java/org/forgerock/openam/sm/ServerGroupConfigurationTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/sm/ServerGroupConfigurationTest.java
@@ -20,7 +20,7 @@ import com.iplanet.services.ldap.ServerGroup;
 import com.iplanet.services.ldap.ServerInstance;
 import java.util.Arrays;
 import java.util.Set;
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import org.forgerock.openam.ldap.LDAPURL;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;

--- a/openam-core/src/test/java/org/forgerock/openam/sm/ServiceConfigQueryFilterVisitorTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/sm/ServiceConfigQueryFilterVisitorTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.sm;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.util.query.QueryFilter.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/openam-core/src/test/java/org/forgerock/openam/sm/datalayer/impl/ldap/CTSDJLDAPv3PersistentSearchTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/sm/datalayer/impl/ldap/CTSDJLDAPv3PersistentSearchTest.java
@@ -15,7 +15,7 @@
 */
 package org.forgerock.openam.sm.datalayer.impl.ldap;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.HashSet;

--- a/openam-core/src/test/java/org/forgerock/openam/sm/datalayer/impl/ldap/ExternalLdapConfigTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/sm/datalayer/impl/ldap/ExternalLdapConfigTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.sm.datalayer.impl.ldap;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.openam.utils.CollectionUtils.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Matchers.anyBoolean;

--- a/openam-core/src/test/java/org/forgerock/openam/sm/datalayer/impl/ldap/LdapQueryBuilderTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/sm/datalayer/impl/ldap/LdapQueryBuilderTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.sm.datalayer.impl.ldap;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.openam.utils.Time.*;
 import static org.mockito.BDDMockito.*;
 

--- a/openam-core/src/test/java/org/forgerock/openam/sm/datalayer/impl/tasks/ContinuousQueryTaskTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/sm/datalayer/impl/tasks/ContinuousQueryTaskTest.java
@@ -15,7 +15,7 @@
 */
 package org.forgerock.openam.sm.datalayer.impl.tasks;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/openam-core/src/test/java/org/forgerock/openam/sm/datalayer/providers/DataLayerConnectionFactoryCacheTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/sm/datalayer/providers/DataLayerConnectionFactoryCacheTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.sm.datalayer.providers;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;

--- a/openam-core/src/test/java/org/forgerock/openam/sm/datalayer/store/TokenDataStoreTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/sm/datalayer/store/TokenDataStoreTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.sm.datalayer.store;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.openam.utils.CollectionUtils.asSet;
 import static org.mockito.Mockito.*;
 

--- a/openam-core/src/test/java/org/forgerock/openam/sm/datalayer/utils/ConnectionConfigFactoryTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/sm/datalayer/utils/ConnectionConfigFactoryTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.sm.datalayer.utils;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import org.forgerock.openam.sm.ConnectionConfig;

--- a/openam-core/src/test/java/org/forgerock/openam/sso/providers/stateless/StatelessAdminRestrictionTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/sso/providers/stateless/StatelessAdminRestrictionTest.java
@@ -16,7 +16,7 @@
 package org.forgerock.openam.sso.providers.stateless;
 
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;

--- a/openam-core/src/test/java/org/forgerock/openam/sso/providers/stateless/StatelessSessionManagerTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/sso/providers/stateless/StatelessSessionManagerTest.java
@@ -22,7 +22,7 @@ import org.forgerock.openam.session.stateless.cache.StatelessJWTCache;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 

--- a/openam-core/src/test/java/org/forgerock/openam/utils/ForwardedHeaderTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/utils/ForwardedHeaderTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.utils;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;

--- a/openam-core/src/test/java/org/forgerock/openam/utils/ModifiedPropertyTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/utils/ModifiedPropertyTest.java
@@ -17,7 +17,7 @@ package org.forgerock.openam.utils;
 
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author robert.wapshott@forgerock.com

--- a/openam-core/src/test/java/org/forgerock/openam/utils/ShutdownMonitorTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/utils/ShutdownMonitorTest.java
@@ -21,7 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.Mockito.when;

--- a/openam-core/src/test/java/org/forgerock/openam/xui/XUIFilterTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/xui/XUIFilterTest.java
@@ -24,7 +24,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.ServletContext;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;

--- a/openam-datastore/pom.xml
+++ b/openam-datastore/pom.xml
@@ -52,10 +52,5 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-testng</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/ADBasicRepoTest.java
+++ b/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/ADBasicRepoTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.idrepo.ldap;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.fail;
 
 import org.forgerock.openam.utils.MapHelper;

--- a/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/ADMailBasedRepoTest.java
+++ b/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/ADMailBasedRepoTest.java
@@ -19,7 +19,7 @@ package org.forgerock.openam.idrepo.ldap;
 import com.sun.identity.idm.IdRepo;
 import com.sun.identity.idm.IdType;
 import com.sun.identity.idm.RepoSearchResults;
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 import org.forgerock.openam.utils.CrestQuery;
 import org.forgerock.openam.utils.MapHelper;

--- a/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/DSEERepoTest.java
+++ b/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/DSEERepoTest.java
@@ -22,7 +22,7 @@ import com.sun.identity.idm.IdRepoException;
 import com.sun.identity.idm.IdType;
 import java.util.Map;
 import java.util.Set;
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.openam.ldap.LDAPConstants.*;
 import static org.forgerock.openam.utils.CollectionUtils.*;
 import static org.testng.Assert.fail;

--- a/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/GenericRepoTest.java
+++ b/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/GenericRepoTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.idrepo.ldap;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.openam.utils.CollectionUtils.asOrderedSet;
 import static org.forgerock.openam.utils.CollectionUtils.asSet;
 import static org.mockito.Mockito.*;

--- a/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/PSearchRepoTest.java
+++ b/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/PSearchRepoTest.java
@@ -21,7 +21,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.fail;
 
 

--- a/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/helpers/ADAMHelperTest.java
+++ b/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/helpers/ADAMHelperTest.java
@@ -18,7 +18,7 @@ package org.forgerock.openam.idrepo.ldap.helpers;
 import com.sun.identity.idm.IdType;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import org.forgerock.openam.utils.CollectionUtils;
 import static org.forgerock.openam.utils.CollectionUtils.*;
 

--- a/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/helpers/DirectoryHelperTest.java
+++ b/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/helpers/DirectoryHelperTest.java
@@ -18,7 +18,7 @@ package org.forgerock.openam.idrepo.ldap.helpers;
 import com.sun.identity.idm.IdType;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import org.forgerock.openam.utils.CollectionUtils;
 import static org.forgerock.openam.utils.CollectionUtils.*;
 

--- a/openam-entitlements/pom.xml
+++ b/openam-entitlements/pom.xml
@@ -106,13 +106,7 @@
 	      <groupId>org.powermock</groupId>
 	      <artifactId>powermock-api-mockito2</artifactId>
 	      <scope>test</scope>
-	   </dependency> 
-	   
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
+	   </dependency>
 
         <dependency>
             <groupId>org.openidentityplatform.commons.guice</groupId>

--- a/openam-entitlements/src/test/java/com/sun/identity/entitlement/xacml3/Assertions.java
+++ b/openam-entitlements/src/test/java/com/sun/identity/entitlement/xacml3/Assertions.java
@@ -30,7 +30,7 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeSet;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Collection of assertion methods for unit tests.

--- a/openam-entitlements/src/test/java/com/sun/identity/entitlement/xacml3/ResourceAttributeUtilTest.java
+++ b/openam-entitlements/src/test/java/com/sun/identity/entitlement/xacml3/ResourceAttributeUtilTest.java
@@ -19,7 +19,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.identity.entitlement.EntitlementException;
 import com.sun.identity.entitlement.ResourceAttribute;
-import org.fest.util.Collections;
+
+import org.forgerock.openam.utils.CollectionUtils;
 import org.testng.annotations.Test;
 
 import javax.security.auth.Subject;
@@ -27,7 +28,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.Matchers.any;
@@ -94,7 +95,7 @@ public class ResourceAttributeUtilTest {
 
         @Override
         public Set<String> getPropertyValues() {
-            return Collections.set("Weasel", "Ferret");
+            return CollectionUtils.asSet("Weasel", "Ferret");
         }
 
         @Override

--- a/openam-entitlements/src/test/java/com/sun/identity/entitlement/xacml3/SearchFilterFactoryTest.java
+++ b/openam-entitlements/src/test/java/com/sun/identity/entitlement/xacml3/SearchFilterFactoryTest.java
@@ -21,7 +21,7 @@ import com.sun.identity.entitlement.util.SearchFilter;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.AssertJUnit.fail;
 
 public class SearchFilterFactoryTest {

--- a/openam-entitlements/src/test/java/com/sun/identity/entitlement/xacml3/XACMLPrivilegeUtilsTest.java
+++ b/openam-entitlements/src/test/java/com/sun/identity/entitlement/xacml3/XACMLPrivilegeUtilsTest.java
@@ -35,7 +35,7 @@ import java.util.Set;
 
 import static com.sun.identity.entitlement.xacml3.Assertions.*;
 import static com.sun.identity.entitlement.xacml3.FactoryMethods.*;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.openam.utils.Time.*;
 import static org.testng.Assert.*;
 

--- a/openam-entitlements/src/test/java/com/sun/identity/entitlement/xacml3/XACMLReaderWriterTest.java
+++ b/openam-entitlements/src/test/java/com/sun/identity/entitlement/xacml3/XACMLReaderWriterTest.java
@@ -18,7 +18,7 @@ package com.sun.identity.entitlement.xacml3;
 
 import static com.sun.identity.entitlement.xacml3.Assertions.*;
 import static com.sun.identity.entitlement.xacml3.FactoryMethods.*;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.openam.utils.Time.getCalendarInstance;
 
 import org.testng.annotations.Test;

--- a/openam-entitlements/src/test/java/com/sun/identity/entitlement/xacml3/XACMLSchemaFactoryTest.java
+++ b/openam-entitlements/src/test/java/com/sun/identity/entitlement/xacml3/XACMLSchemaFactoryTest.java
@@ -36,7 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for {@link com.sun.identity.entitlement.xacml3.XACMLSchemaFactory}.

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/conditions/environment/IPvXConditionTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/conditions/environment/IPvXConditionTest.java
@@ -29,7 +29,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.security.auth.Subject;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.JsonValue.array;
 import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/conditions/environment/LDAPFilterConditionTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/conditions/environment/LDAPFilterConditionTest.java
@@ -7,7 +7,7 @@ import org.testng.annotations.Test;
 
 import javax.security.auth.Subject;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class LDAPFilterConditionTest {

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/conditions/environment/ScriptConditionTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/conditions/environment/ScriptConditionTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.entitlement.conditions.environment;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.Mockito.mock;

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/constraints/ConstraintValidatorImplTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/constraints/ConstraintValidatorImplTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.entitlement.constraints;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.sun.identity.entitlement.URLResourceName;
 import org.forgerock.openam.entitlement.ResourceType;

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/ConditionTypesResourceTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/ConditionTypesResourceTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.entitlement.rest;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/DecisionCombinersResourceTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/DecisionCombinersResourceTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.entitlement.rest;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/EntitlementTestUtils.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/EntitlementTestUtils.java
@@ -15,12 +15,13 @@
  */
 package org.forgerock.openam.entitlement.rest;
 
-import static org.fest.assertions.Fail.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.forgerock.json.resource.test.assertj.AssertJResourceResponseAssert.assertThat;
 
 import com.sun.identity.entitlement.EntitlementException;
+
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
-import org.fest.assertions.Assertions;
 import org.forgerock.json.resource.QueryResponse;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourceResponse;

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/EntitlementsExceptionMappingHandlerTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/EntitlementsExceptionMappingHandlerTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.entitlement.rest;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.json.JsonValue.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.mock;

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/JsonPolicyParserTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/JsonPolicyParserTest.java
@@ -51,8 +51,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.forgerock.json.JsonValue.*;
 
 public class JsonPolicyParserTest {
@@ -208,7 +208,7 @@ public class JsonPolicyParserTest {
         Privilege result = parser.parsePolicy(POLICY_NAME, content);
 
         // Then
-        assertThat(result.getEntitlement().getResourceNames()).containsOnly(included.toArray());
+        assertThat(result.getEntitlement().getResourceNames()).containsOnlyElementsOf(included);
     }
 
     @Test
@@ -450,7 +450,7 @@ public class JsonPolicyParserTest {
         ResourceAttribute attr = result.getResourceAttributes().iterator().next();
         assertThat(attr).isInstanceOf(StaticAttributes.class);
         assertThat(attr.getPropertyName()).isEqualTo("test");
-        assertThat(attr.getPropertyValues()).containsOnly(values.toArray());
+        assertThat(attr.getPropertyValues()).containsOnlyElementsOf(values);
     }
 
     @Test
@@ -673,7 +673,7 @@ public class JsonPolicyParserTest {
         assertThat(result.get(new JsonPointer("condition/conditions/0/condition/className")).asString())
                 .isEqualTo(AuthenticateToRealmCondition.class.getName());
         assertThat(result.get(new JsonPointer("condition/conditions/0/condition/properties")).asMapOfList(String.class))
-                .includes(entry("AuthenticateToRealm", Arrays.asList("REALM")));
+                .contains(entry("AuthenticateToRealm", Arrays.asList("REALM")));
     }
 
     @Test
@@ -714,7 +714,7 @@ public class JsonPolicyParserTest {
         assertThat(result.get(new JsonPointer("resourceAttributes/1/propertyName")).asString())
                 .isEqualTo(staticAttrName);
         assertThat(result.get(new JsonPointer("resourceAttributes/1/propertyValues")).asList(String.class))
-                .containsOnly(staticAttrValue.toArray());
+                .containsOnlyElementsOf(staticAttrValue);
     }
 
     private JsonValue buildJson(Map.Entry<String, Object> fieldValue) {

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/PolicyRequestFactoryTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/PolicyRequestFactoryTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.entitlement.rest;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/PolicyV1FilterTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/PolicyV1FilterTest.java
@@ -16,7 +16,7 @@
  */
 package org.forgerock.openam.entitlement.rest;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.JsonValue.*;
 import static org.forgerock.json.resource.Responses.*;
 import static org.forgerock.json.resource.test.assertj.AssertJActionResponseAssert.assertThat;

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/PrivilegePolicyStoreProviderTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/PrivilegePolicyStoreProviderTest.java
@@ -32,7 +32,7 @@ import javax.security.auth.Subject;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/PrivilegePolicyStoreTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/PrivilegePolicyStoreTest.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.singleton;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.openam.utils.CollectionUtils.asSet;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.anySetOf;

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/ResourceTypesResourceTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/ResourceTypesResourceTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.entitlement.rest;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.JsonValue.*;
 import static org.forgerock.json.resource.test.assertj.AssertJQueryResponseAssert.assertThat;
 import static org.forgerock.json.resource.test.assertj.AssertJResourceResponseAssert.assertThat;

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/SubjectTypesResourceTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/SubjectTypesResourceTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.entitlement.rest;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.resource.test.assertj.AssertJQueryResponseAssert.assertThat;
 import static org.forgerock.json.resource.test.assertj.AssertJResourceResponseAssert.assertThat;
 import static org.mockito.BDDMockito.given;

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/model/json/BatchPolicyRequestTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/model/json/BatchPolicyRequestTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.entitlement.rest.model.json;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/model/json/PolicyRequestTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/model/json/PolicyRequestTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.entitlement.rest.model.json;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.JsonValue.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -38,7 +38,7 @@ import com.sun.identity.entitlement.EntitlementException;
 import com.sun.identity.entitlement.JwtPrincipal;
 import com.sun.identity.shared.Constants;
 
-import org.fest.assertions.Condition;
+import org.assertj.core.api.Condition;
 import org.forgerock.openam.core.realms.Realm;
 import org.forgerock.openam.core.realms.RealmTestHelper;
 import org.forgerock.services.context.Context;

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/model/json/TreePolicyRequestTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/model/json/TreePolicyRequestTest.java
@@ -37,7 +37,7 @@ import javax.security.auth.Subject;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 

--- a/openam-federation/OpenFM/pom.xml
+++ b/openam-federation/OpenFM/pom.xml
@@ -167,12 +167,6 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
-  
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/openam-federation/OpenFM/src/test/java/com/sun/identity/entitlement/EntitlementTest.java
+++ b/openam-federation/OpenFM/src/test/java/com/sun/identity/entitlement/EntitlementTest.java
@@ -37,7 +37,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author dillidorai

--- a/openam-federation/openam-federation-library/pom.xml
+++ b/openam-federation/openam-federation-library/pom.xml
@@ -195,11 +195,6 @@
             <groupId>org.openidentityplatform.openam</groupId>
             <artifactId>openam-idpdiscovery</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-        </dependency>
         
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/openam-federation/openam-federation-library/src/test/java/com/sun/identity/saml2/profile/IDPRequestValidatorTest.java
+++ b/openam-federation/openam-federation-library/src/test/java/com/sun/identity/saml2/profile/IDPRequestValidatorTest.java
@@ -24,7 +24,7 @@ import org.testng.annotations.Test;
 
 import javax.servlet.http.HttpServletRequest;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 

--- a/openam-federation/openam-federation-library/src/test/java/com/sun/identity/saml2/profile/SLOLocationTest.java
+++ b/openam-federation/openam-federation-library/src/test/java/com/sun/identity/saml2/profile/SLOLocationTest.java
@@ -20,7 +20,7 @@ import com.sun.identity.saml2.jaxb.metadata.SingleLogoutServiceElement;
 import com.sun.identity.saml2.jaxb.metadata.impl.SingleLogoutServiceElementImpl;
 import java.util.ArrayList;
 import java.util.List;
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import org.testng.annotations.Test;
 
 @Test

--- a/openam-ldap-utils/pom.xml
+++ b/openam-ldap-utils/pom.xml
@@ -51,9 +51,5 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/openam-ldap-utils/src/test/java/org/forgerock/openam/ldap/LDAPPriorityListingTest.java
+++ b/openam-ldap-utils/src/test/java/org/forgerock/openam/ldap/LDAPPriorityListingTest.java
@@ -18,7 +18,7 @@ package org.forgerock.openam.ldap;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.openam.utils.CollectionUtils.*;
 import static org.testng.Assert.assertEquals;
 

--- a/openam-ldap-utils/src/test/java/org/forgerock/openam/ldap/LDAPURLParsingTest.java
+++ b/openam-ldap-utils/src/test/java/org/forgerock/openam/ldap/LDAPURLParsingTest.java
@@ -16,7 +16,7 @@
 package org.forgerock.openam.ldap;
 
 import org.testng.annotations.Test;
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 @Test
 public class LDAPURLParsingTest {

--- a/openam-oauth2/pom.xml
+++ b/openam-oauth2/pom.xml
@@ -142,15 +142,6 @@
             <groupId>org.openidentityplatform.openam</groupId>
             <artifactId>openam-restlet</artifactId>
         </dependency>
-
-
-
-        <!-- Test Dependencies -->
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>

--- a/openam-oauth2/src/test/java/org/forgerock/oauth2/core/OAuth2ProviderSettingsFactoryTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/oauth2/core/OAuth2ProviderSettingsFactoryTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.oauth2.core;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/openam-oauth2/src/test/java/org/forgerock/oauth2/core/OAuth2RequestFactoryTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/oauth2/core/OAuth2RequestFactoryTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.oauth2.core;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;

--- a/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/AgentClientRegistrationTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/AgentClientRegistrationTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.oauth2;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/OpenAMClientRegistrationStoreTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/OpenAMClientRegistrationStoreTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.oauth2;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;

--- a/openam-rest/pom.xml
+++ b/openam-rest/pom.xml
@@ -130,13 +130,6 @@
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
         </dependency>
-
-        <!-- Test Dependencies -->
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>

--- a/openam-rest/src/test/java/org/forgerock/openam/forgerockrest/utils/MailServerLoaderTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/forgerockrest/utils/MailServerLoaderTest.java
@@ -19,7 +19,7 @@ import org.forgerock.openam.services.email.MailServer;
 import org.forgerock.openam.services.email.MailServerImpl;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MailServerLoaderTest {
     @Test

--- a/openam-rest/src/test/java/org/forgerock/openam/forgerockrest/utils/XMLResourceExceptionHandlerTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/forgerockrest/utils/XMLResourceExceptionHandlerTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.forgerockrest.utils;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 

--- a/openam-rest/src/test/java/org/forgerock/openam/notifications/NotificationsWebSocketFilterTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/notifications/NotificationsWebSocketFilterTest.java
@@ -19,7 +19,7 @@ package org.forgerock.openam.notifications;
 import static com.sun.identity.common.configuration.AgentConfiguration.*;
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import java.security.PrivilegedAction;

--- a/openam-rest/src/test/java/org/forgerock/openam/rest/authz/PrivilegeAuthzModuleTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/rest/authz/PrivilegeAuthzModuleTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.rest.authz;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;

--- a/openam-rest/src/test/java/org/forgerock/openam/rest/query/PagingQueryResponseHandlerTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/rest/query/PagingQueryResponseHandlerTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.rest.query;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.resource.Responses.newResourceResponse;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;

--- a/openam-rest/src/test/java/org/forgerock/openam/rest/query/QueryByStringFilterConverterTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/rest/query/QueryByStringFilterConverterTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.rest.query;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.util.query.QueryFilter.*;
 import static org.mockito.Mockito.*;
 

--- a/openam-rest/src/test/java/org/forgerock/openam/rest/query/QueryExceptionTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/rest/query/QueryExceptionTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.rest.query;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.openam.rest.query.QueryException.QueryErrorCode.*;
 
 import org.testng.annotations.Test;

--- a/openam-restlet/pom.xml
+++ b/openam-restlet/pom.xml
@@ -97,13 +97,6 @@
             <groupId>org.openidentityplatform.commons.authn-filter</groupId>
             <artifactId>jaspi-runtime</artifactId>
         </dependency>
-
-        <!-- Test Dependencies -->
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>

--- a/openam-restlet/src/test/java/org/forgerock/openam/rest/representations/JacksonRepresentationFactoryTest.java
+++ b/openam-restlet/src/test/java/org/forgerock/openam/rest/representations/JacksonRepresentationFactoryTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.rest.representations;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.HashMap;

--- a/openam-scripting/pom.xml
+++ b/openam-scripting/pom.xml
@@ -116,11 +116,6 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/openam-scripting/src/test/java/org/forgerock/openam/scripting/AbstractSandboxTests.java
+++ b/openam-scripting/src/test/java/org/forgerock/openam/scripting/AbstractSandboxTests.java
@@ -28,7 +28,7 @@ import javax.script.SimpleBindings;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.fail;
 
 /**

--- a/openam-scripting/src/test/java/org/forgerock/openam/scripting/ChainedBindingsTest.java
+++ b/openam-scripting/src/test/java/org/forgerock/openam/scripting/ChainedBindingsTest.java
@@ -6,7 +6,7 @@ import org.testng.annotations.Test;
 import javax.script.Bindings;
 import javax.script.SimpleBindings;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ChainedBindingsTest {
 

--- a/openam-scripting/src/test/java/org/forgerock/openam/scripting/GroovyValidatorTest.java
+++ b/openam-scripting/src/test/java/org/forgerock/openam/scripting/GroovyValidatorTest.java
@@ -32,7 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Groovy validation tests.

--- a/openam-scripting/src/test/java/org/forgerock/openam/scripting/JavaScriptValidatorTest.java
+++ b/openam-scripting/src/test/java/org/forgerock/openam/scripting/JavaScriptValidatorTest.java
@@ -31,7 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @GuiceModules({SharedGuiceModule.class, ScriptingGuiceModule.class})
 public class JavaScriptValidatorTest extends GuiceTestCase {

--- a/openam-scripting/src/test/java/org/forgerock/openam/scripting/StandardScriptEngineManagerTest.java
+++ b/openam-scripting/src/test/java/org/forgerock/openam/scripting/StandardScriptEngineManagerTest.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StandardScriptEngineManagerTest {
 

--- a/openam-scripting/src/test/java/org/forgerock/openam/scripting/StandardScriptEvaluatorTest.java
+++ b/openam-scripting/src/test/java/org/forgerock/openam/scripting/StandardScriptEvaluatorTest.java
@@ -27,7 +27,7 @@ import javax.script.SimpleBindings;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StandardScriptEvaluatorTest {
 

--- a/openam-scripting/src/test/java/org/forgerock/openam/scripting/ThreadPoolScriptEvaluatorTest.java
+++ b/openam-scripting/src/test/java/org/forgerock/openam/scripting/ThreadPoolScriptEvaluatorTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.scripting;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.openam.scripting.StandardScriptEvaluatorTest.getGroovyScript;
 import static org.forgerock.openam.scripting.StandardScriptEvaluatorTest.getJavascript;
 import static org.mockito.BDDMockito.given;

--- a/openam-scripting/src/test/java/org/forgerock/openam/scripting/factories/GroovyEngineFactoryTest.java
+++ b/openam-scripting/src/test/java/org/forgerock/openam/scripting/factories/GroovyEngineFactoryTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 
 import javax.script.ScriptEngine;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class GroovyEngineFactoryTest {

--- a/openam-scripting/src/test/java/org/forgerock/openam/scripting/factories/RhinoCompiledScriptTest.java
+++ b/openam-scripting/src/test/java/org/forgerock/openam/scripting/factories/RhinoCompiledScriptTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 import javax.script.ScriptContext;
 import javax.script.ScriptException;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/openam-scripting/src/test/java/org/forgerock/openam/scripting/factories/RhinoScriptEngineTest.java
+++ b/openam-scripting/src/test/java/org/forgerock/openam/scripting/factories/RhinoScriptEngineTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Basic tests of the rhino script engine. The engine is more fully tested by the

--- a/openam-scripting/src/test/java/org/forgerock/openam/scripting/factories/SandboxedGroovyScriptEngineTest.java
+++ b/openam-scripting/src/test/java/org/forgerock/openam/scripting/factories/SandboxedGroovyScriptEngineTest.java
@@ -30,7 +30,7 @@ import javax.script.SimpleScriptContext;
 import java.io.Reader;
 import java.io.StringReader;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/openam-scripting/src/test/java/org/forgerock/openam/scripting/sandbox/GroovySandboxValueFilterTest.java
+++ b/openam-scripting/src/test/java/org/forgerock/openam/scripting/sandbox/GroovySandboxValueFilterTest.java
@@ -20,7 +20,7 @@ import org.mozilla.javascript.ClassShutter;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 

--- a/openam-scripting/src/test/java/org/forgerock/openam/scripting/sandbox/RhinoSandboxClassShutterTest.java
+++ b/openam-scripting/src/test/java/org/forgerock/openam/scripting/sandbox/RhinoSandboxClassShutterTest.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;
 
 public class RhinoSandboxClassShutterTest {

--- a/openam-shared/pom.xml
+++ b/openam-shared/pom.xml
@@ -135,11 +135,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>

--- a/openam-shared/src/test/java/com/iplanet/security/x509/CertUtilsTest.java
+++ b/openam-shared/src/test/java/com/iplanet/security/x509/CertUtilsTest.java
@@ -21,7 +21,7 @@ import javax.security.auth.x500.X500Principal;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class CertUtilsTest {
 

--- a/openam-shared/src/test/java/com/sun/identity/common/CaseInsensitiveHashSetTest.java
+++ b/openam-shared/src/test/java/com/sun/identity/common/CaseInsensitiveHashSetTest.java
@@ -20,7 +20,7 @@ import java.util.Set;
 
 import org.forgerock.openam.utils.CollectionUtils;
 import org.testng.annotations.Test;
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class CaseInsensitiveHashSetTest {
 

--- a/openam-shared/src/test/java/com/sun/identity/shared/DateUtilsTest.java
+++ b/openam-shared/src/test/java/com/sun/identity/shared/DateUtilsTest.java
@@ -25,7 +25,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class DateUtilsTest {
 

--- a/openam-shared/src/test/java/com/sun/identity/shared/StringUtilsTest.java
+++ b/openam-shared/src/test/java/com/sun/identity/shared/StringUtilsTest.java
@@ -17,7 +17,7 @@ package com.sun.identity.shared;
 
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class StringUtilsTest {
 

--- a/openam-shared/src/test/java/com/sun/identity/shared/whitelist/PrefixResourceNameTest.java
+++ b/openam-shared/src/test/java/com/sun/identity/shared/whitelist/PrefixResourceNameTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 import java.net.MalformedURLException;
 import java.util.HashMap;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Exercises the behaviour of {@link PrefixResourceName}.

--- a/openam-shared/src/test/java/com/sun/identity/shared/whitelist/URLResourceNameTest.java
+++ b/openam-shared/src/test/java/com/sun/identity/shared/whitelist/URLResourceNameTest.java
@@ -15,11 +15,10 @@
  */
 package com.sun.identity.shared.whitelist;
 
-import org.fest.assertions.ComparisonFailureFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit test for URLResourceName.
@@ -39,7 +38,7 @@ public class URLResourceNameTest {
      * Tests that the normalisation process adheres to the expected rules.
      */
     @Test
-    public void verifyPortHandling() {
+    public void verifyPortHandling() throws Exception {
         // Previous ports are maintained.
         assertNormalisation("http://www.example.com:80/hello", "http://www.example.com:80/hello");
         assertNormalisation("http://www.example.com:12345/hello", "http://www.example.com:12345/hello");
@@ -69,13 +68,7 @@ public class URLResourceNameTest {
      * @param treatedResource
      *         The expected resource after it's been normalised.
      */
-    private void assertNormalisation(String untreatedResource, String treatedResource) {
-        try {
-            assertThat(resourceName.canonicalize(untreatedResource)).isEqualTo(treatedResource);
-        } catch (Exception e) {
-            String message = "Normalisation failed: " + e.getMessage();
-            throw ComparisonFailureFactory.comparisonFailure(message, treatedResource, "");
-        }
+    private void assertNormalisation(String untreatedResource, String treatedResource) throws Exception {
+        assertThat(resourceName.canonicalize(untreatedResource)).isEqualTo(treatedResource);
     }
-
 }

--- a/openam-shared/src/test/java/com/sun/identity/shared/xml/XMLUtilsTest.java
+++ b/openam-shared/src/test/java/com/sun/identity/shared/xml/XMLUtilsTest.java
@@ -18,7 +18,7 @@ package com.sun.identity.shared.xml;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class XMLUtilsTest {
 

--- a/openam-shared/src/test/java/org/forgerock/openam/monitoring/RateWindowTest.java
+++ b/openam-shared/src/test/java/org/forgerock/openam/monitoring/RateWindowTest.java
@@ -24,7 +24,7 @@ import org.testng.annotations.Test;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RateWindowTest {
 

--- a/openam-shared/src/test/java/org/forgerock/openam/shared/concurrency/LockFactoryTest.java
+++ b/openam-shared/src/test/java/org/forgerock/openam/shared/concurrency/LockFactoryTest.java
@@ -18,7 +18,7 @@ package org.forgerock.openam.shared.concurrency;
 import java.util.concurrent.locks.Lock;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test exercises the functionality of {@link LockFactory}.

--- a/openam-shared/src/test/java/org/forgerock/openam/shared/security/whitelist/RedirectUrlValidatorTest.java
+++ b/openam-shared/src/test/java/org/forgerock/openam/shared/security/whitelist/RedirectUrlValidatorTest.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.openam.utils.CollectionUtils.*;
 
 public class RedirectUrlValidatorTest {

--- a/openam-shared/src/test/java/org/forgerock/openam/utils/CollectionUtilsTest.java
+++ b/openam-shared/src/test/java/org/forgerock/openam/utils/CollectionUtilsTest.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit test for {@link CollectionUtils}.

--- a/openam-shared/src/test/java/org/forgerock/openam/utils/JCECipherProviderTest.java
+++ b/openam-shared/src/test/java/org/forgerock/openam/utils/JCECipherProviderTest.java
@@ -24,7 +24,7 @@ import javax.crypto.Cipher;
 import java.security.Provider;
 import java.security.Security;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**

--- a/openam-shared/src/test/java/org/forgerock/openam/utils/PerThreadCipherProviderTest.java
+++ b/openam-shared/src/test/java/org/forgerock/openam/utils/PerThreadCipherProviderTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**

--- a/openam-shared/src/test/java/org/forgerock/openam/utils/PerThreadDocumentBuilderProviderTest.java
+++ b/openam-shared/src/test/java/org/forgerock/openam/utils/PerThreadDocumentBuilderProviderTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**

--- a/openam-shared/src/test/java/org/forgerock/openam/utils/PerThreadSAXParserProviderTest.java
+++ b/openam-shared/src/test/java/org/forgerock/openam/utils/PerThreadSAXParserProviderTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**

--- a/openam-shared/src/test/java/org/forgerock/openam/utils/SafeDocumentBuilderProviderTest.java
+++ b/openam-shared/src/test/java/org/forgerock/openam/utils/SafeDocumentBuilderProviderTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 
 import javax.xml.parsers.DocumentBuilder;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for {@link SafeDocumentBuilderProvider}. Assumes that the underlying

--- a/openam-shared/src/test/java/org/forgerock/openam/utils/SafeSAXParserProviderTest.java
+++ b/openam-shared/src/test/java/org/forgerock/openam/utils/SafeSAXParserProviderTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 
 import javax.xml.parsers.SAXParser;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Basic unit tests for {@link SafeSAXParserProvider}. Assumes the underlying {@link org.forgerock.util.xml.XMLUtils}

--- a/openam-shared/src/test/java/org/forgerock/openam/utils/SingleValueMapperTest.java
+++ b/openam-shared/src/test/java/org/forgerock/openam/utils/SingleValueMapperTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.utils;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;

--- a/openam-shared/src/test/java/org/forgerock/openam/utils/StringUtilsTest.java
+++ b/openam-shared/src/test/java/org/forgerock/openam/utils/StringUtilsTest.java
@@ -19,7 +19,7 @@
 
 package org.forgerock.openam.utils;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.UnsupportedEncodingException;
 import java.util.regex.Pattern;

--- a/openam-shared/src/test/java/org/forgerock/openam/utils/collections/LeastRecentlyUsedTest.java
+++ b/openam-shared/src/test/java/org/forgerock/openam/utils/collections/LeastRecentlyUsedTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.utils.collections;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.UUID;
 

--- a/openam-sts/openam-client-sts/pom.xml
+++ b/openam-sts/openam-client-sts/pom.xml
@@ -56,12 +56,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-
-        <!-- Test dependencies -->
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-        </dependency>
          <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/openam-sts/openam-client-sts/src/test/java/org/forgerock/openam/sts/config/user/AuthTargetMappingTest.java
+++ b/openam-sts/openam-client-sts/src/test/java/org/forgerock/openam/sts/config/user/AuthTargetMappingTest.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AuthTargetMappingTest {
     private static final String USERNAME = "username";

--- a/openam-sts/openam-common-sts/pom.xml
+++ b/openam-sts/openam-common-sts/pom.xml
@@ -79,10 +79,5 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/openam-upgrade/pom.xml
+++ b/openam-upgrade/pom.xml
@@ -80,12 +80,6 @@
             <groupId>javax.servlet.jsp</groupId>
             <artifactId>jsp-api</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>

--- a/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/steps/DelegationConfigUpgradeStepTest.java
+++ b/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/steps/DelegationConfigUpgradeStepTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.upgrade.steps;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;

--- a/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/steps/UpgradeEntitlementSubConfigsStepTest.java
+++ b/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/steps/UpgradeEntitlementSubConfigsStepTest.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.openam.upgrade.steps;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.security.PrivilegedAction;

--- a/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/steps/UpgradeExternalCTSConfigurationStepTest.java
+++ b/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/steps/UpgradeExternalCTSConfigurationStepTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.upgrade.steps;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.security.PrivilegedAction;

--- a/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/steps/UpgradeServerDefaultsStepTest.java
+++ b/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/steps/UpgradeServerDefaultsStepTest.java
@@ -15,7 +15,7 @@
  */
 package org.forgerock.openam.upgrade.steps;
 
-import static org.fest.assertions.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.forgerock.openam.utils.CollectionUtils.*;
 import static org.mockito.Mockito.*;
 

--- a/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/steps/policy/conditions/PolicyConditionUpgraderTest.java
+++ b/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/steps/policy/conditions/PolicyConditionUpgraderTest.java
@@ -30,7 +30,7 @@ import com.sun.identity.entitlement.opensso.PolicyCondition;
 import com.sun.identity.entitlement.opensso.PolicySubject;
 import java.util.HashSet;
 import java.util.Set;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.forgerock.openam.upgrade.UpgradeException;
 import org.mockito.ArgumentCaptor;
 import static org.mockito.BDDMockito.given;

--- a/pom.xml
+++ b/pom.xml
@@ -1576,12 +1576,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.easytesting</groupId>
-        <artifactId>fest-assert</artifactId>
-        <version>1.4</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
         <version>3.2</version>


### PR DESCRIPTION
I've used open-rewrite for most of this with the following config:

```
type: specs.openrewrite.org/v1beta/recipe
name: com.example.UpdateFestAssertStaticImport
displayName: Replace constant with another constant example
recipeList:
  - org.openrewrite.java.ChangeMethodName:
      methodPattern: org.fest.assertions.GenericAssert#satisfies(org.fest.assertions.Condition)
      newMethodName: is
  - org.openrewrite.java.ChangeMethodName:
      methodPattern: org.fest.assertions.MapAssert#includes(org.fest.assertions.MapAssert.Entry[])
      newMethodName: contains
  - org.openrewrite.java.ChangeMethodName:
      methodPattern: org.fest.assertions.ObjectGroupAssert#excludes(Object[])
      newMethodName: doesNotContain
  - org.openrewrite.java.ChangeMethodName:
      methodPattern: org.fest.util.Collections#list(..)
      newMethodName: asList
  - org.openrewrite.java.ChangeMethodTargetToStatic:
      methodPattern: org.fest.util.Collections#asList(..)
      fullyQualifiedTargetTypeName: org.forgerock.openam.utils.CollectionUtils
  - org.openrewrite.java.ChangeMethodName:
      methodPattern: org.fest.util.Collections#set(..)
      newMethodName: asSet
  - org.openrewrite.java.ChangeMethodTargetToStatic:
      methodPattern: org.fest.util.Collections#asSet(..)
      fullyQualifiedTargetTypeName: org.forgerock.openam.utils.CollectionUtils
  - org.openrewrite.java.ChangeType:
      oldFullyQualifiedTypeName: org.fest.assertions.Assertions
      newFullyQualifiedTypeName: org.assertj.core.api.Assertions
  - org.openrewrite.java.ChangeType:
      oldFullyQualifiedTypeName: org.fest.assertions.Condition
      newFullyQualifiedTypeName: org.assertj.core.api.Condition
  - org.openrewrite.java.ChangeMethodTargetToStatic:
      methodPattern: org.fest.assertions.MapAssert#entry(..)
      fullyQualifiedTargetTypeName: org.assertj.core.api.Assertions
      returnType: org.assertj.core.data.MapEntry
  - org.openrewrite.java.ChangeMethodTargetToStatic:
      methodPattern: org.fest.assertions.Fail#fail(..)
      fullyQualifiedTargetTypeName: org.assertj.core.api.Assertions
  - org.openrewrite.java.ChangeMethodTargetToStatic:
      methodPattern: org.fest.util.Collections#list(..)
      fullyQualifiedTargetTypeName: java.util.Collections
  - org.openrewrite.maven.AddManagedDependency:
      groupId: org.assertj
      artifactId: assertj-core
      version: 2.4.1
      scope: test
  - org.openrewrite.maven.RemoveDependency:
      groupId: org.easytesting
      artifactId: fest-assert
      scope: test
```