### PR TITLE
Fix OAuth2 issues: Restore 'none' token endpoint auth method. Do not add default openid scope if non-empty.

### DIFF
--- a/openam-oauth2/src/main/java/org/forgerock/openidconnect/Client.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openidconnect/Client.java
@@ -217,9 +217,9 @@ public class Client extends JsonValue {
         /** Client secret post type. */
      //   CLIENT_SECRET_JWT("client_secret_jwt"), todo uncomment as we add suppot
         /** Client secret basic type. */
-        PRIVATE_KEY_JWT("private_key_jwt");
+        PRIVATE_KEY_JWT("private_key_jwt"),
         /** None type. */
-     //   NONE("none");
+        NONE("none");
 
         private String type;
 

--- a/openam-oauth2/src/main/java/org/forgerock/openidconnect/Client.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openidconnect/Client.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2014-2016 ForgeRock AS.
  * Portions Copyrighted 2015 Nomura Research Institute, Ltd.
+ * Portions Copyrighted 2025 3A Systems LLC.
  */
 
 package org.forgerock.openidconnect;

--- a/openam-oauth2/src/main/java/org/forgerock/openidconnect/OpenIdConnectClientRegistrationService.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openidconnect/OpenIdConnectClientRegistrationService.java
@@ -271,13 +271,13 @@ public class OpenIdConnectClientRegistrationService {
                     throw new InvalidClientMetadata("Invalid scopes requested");
                 }
             } else { //if nothing requested, fall back to provider defaults
-                scopes = new ArrayList<String>();
+                scopes = new ArrayList<>();
                 scopes.addAll(providerSettings.getDefaultScopes());
             }
 
             //regardless, we add openid
-            if (!scopes.contains(OPENID)) {
-                scopes = new ArrayList<String>(scopes);
+            if (scopes.isEmpty()) {
+                scopes = new ArrayList<>();
                 scopes.add(OPENID);
             }
 

--- a/openam-server-only/src/main/resources/services/AgentService.xml
+++ b/openam-server-only/src/main/resources/services/AgentService.xml
@@ -28,6 +28,7 @@
 
    Portions Copyrighted 2011-2016 ForgeRock AS.
    Portions Copyrighted 2015 Nomura Research Institute, Ltd.
+   Portions Copyrighted 2025 3A Systems LLC.
 -->
 
 <!DOCTYPE ServicesConfiguration

--- a/openam-server-only/src/main/resources/services/AgentService.xml
+++ b/openam-server-only/src/main/resources/services/AgentService.xml
@@ -36,7 +36,7 @@
 
 <ServicesConfiguration>
     <Service name="AgentService" version="1.0">
-        <Schema i18nFileName="agentService" revisionNumber="10">
+        <Schema i18nFileName="agentService" revisionNumber="11">
             <Organization>
                 <SubSchema name="OAuth2Client" inheritance="multiple" i18nKey="a7001" hideConfigUI="yes">
                     <AttributeSchema
@@ -181,6 +181,7 @@
                             <ChoiceValue i18nKey="a741">client_secret_basic</ChoiceValue>
                             <!--     <ChoiceValue i18nKey="a742">client_secret_jwt</ChoiceValue> -->
                             <ChoiceValue i18nKey="a743">private_key_jwt</ChoiceValue>
+                            <ChoiceValue>none</ChoiceValue>
                         </ChoiceValues>
                         <DefaultValues>
                             <Value>client_secret_basic</Value>


### PR DESCRIPTION
[Restore 'none' token endpoint auth method.](https://github.com/OpenIdentityPlatform/OpenAM/commit/8747ea27cb0468f18a4d46f02a8388e6e6380ff2)

[Do not add default openid scope if non-empty](https://github.com/OpenIdentityPlatform/OpenAM/commit/c2376b21447fcfe81bb10f3bba06db1d65762997)