### PR TITLE
Include `acr` and `amr` claims in stateless JWT access tokens

### DIFF
--- a/openam-documentation/openam-doc-source/src/main/asciidoc/admin-guide/chap-openid-connect.adoc
+++ b/openam-documentation/openam-doc-source/src/main/asciidoc/admin-guide/chap-openid-connect.adoc
@@ -12,7 +12,7 @@
   information: "Portions copyright [year] [name of copyright owner]".
  
   Copyright 2017 ForgeRock AS.
-  Portions Copyright 2024-2025 3A Systems LLC.
+  Portions Copyright 2024-2026 3A Systems LLC.
 ////
 
 :figure-caption!:
@@ -798,10 +798,22 @@ $ curl http://openam.example.com:8080/openam/oauth2/tokeninfo?access_token=eyAid
      "openid":"",
      "jti":"f8010f16-fba4-485e-84c5-c68e6296f21c",
      "token_type":"Bearer",
+     "acr":"urn:mace:incommon:iap:silver",
+     "authModules":"DataStore",
      "access_token":"eyAid...1knJDss",
      "profile":""
  }
 ----
++
+[NOTE]
+====
+The `acr` (Authentication Context Class Reference) and `authModules` claims are
+included in the stateless access token only when the originating authorization
+code or refresh token carries this information, for example when the access
+token is issued through the `authorization_code` or `refresh_token` grant. When
+no such data is available (for example, with the `client_credentials` grant),
+these claims are omitted.
+====
 
 ====
 

--- a/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/StatelessTokenStore.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/StatelessTokenStore.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions copyright 2025 3A Systems LLC.
+ * Portions copyright 2020-2026 3A Systems LLC.
  */
 
 package org.forgerock.openam.oauth2;
@@ -234,8 +234,29 @@ public class StatelessTokenStore implements TokenStore {
                 .claim(AUDIT_TRACKING_ID, UUID.randomUUID().toString())
                 .claim(AUTH_GRANT_ID, refreshToken != null ? refreshToken.getAuthGrantId() : UUID.randomUUID().toString())
                 .claim(AUTH_TIME, authTime);
-        
-        
+
+        // Propagate authentication context (acr) and authentication modules (amr) into the
+        // stateless JWT access token, mirroring the behaviour of createRefreshToken. The values
+        // are sourced from the AuthorizationCode (authorization_code grant) or from the previous
+        // RefreshToken (refresh_token grant), so PEPs/API gateways can read acr/amr directly from
+        // the access token payload without an extra /oauth2/tokeninfo round-trip.
+        String authModules = null;
+        String acr = null;
+        if (authCode != null) {
+            authModules = authCode.getAuthModules();
+            acr = authCode.getAuthenticationContextClassReference();
+        }
+        RefreshToken currentRefreshToken = request.getToken(RefreshToken.class);
+        if (currentRefreshToken != null) {
+            authModules = currentRefreshToken.getAuthModules();
+            acr = currentRefreshToken.getAuthenticationContextClassReference();
+        }
+        if (authModules != null) {
+            claimsSetBuilder.claim(AUTH_MODULES, authModules);
+        }
+        if (acr != null) {
+            claimsSetBuilder.claim(ACR, acr);
+        }
 
         JsonValue confirmationJwk = utils.getConfirmationKey(request);
         if (confirmationJwk != null) {

--- a/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/StatelessTokenStoreTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/StatelessTokenStoreTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2026 3A Systems LLC.
  */
 package org.forgerock.openam.oauth2;
 
@@ -19,14 +20,17 @@ import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.JsonValue.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import com.sun.identity.shared.debug.Debug;
 import org.forgerock.json.jose.builders.JwtBuilderFactory;
 import org.forgerock.oauth2.core.AccessToken;
+import org.forgerock.oauth2.core.AuthorizationCode;
 import org.forgerock.oauth2.core.OAuth2ProviderSettings;
 import org.forgerock.oauth2.core.OAuth2ProviderSettingsFactory;
 import org.forgerock.oauth2.core.OAuth2Request;
 import org.forgerock.oauth2.core.OAuth2Uris;
+import org.forgerock.oauth2.core.RefreshToken;
 import org.forgerock.openam.blacklist.Blacklist;
 import org.forgerock.openam.blacklist.Blacklistable;
 import org.forgerock.openam.cts.CTSPersistentStore;
@@ -127,6 +131,100 @@ public final class StatelessTokenStoreTest {
 
         // Then
         assertThat(token.getConfirmationKey().isNull()).isTrue();
+    }
+
+    @Test
+    public void whenAuthorizationCodePresentAcrAndAmrGetAddedToAccessToken() throws Exception {
+        // Given
+        givenBaseProviderSettings();
+        given(utils.getConfirmationKey(request)).willReturn(null);
+
+        AuthorizationCode authorizationCode = mock(AuthorizationCode.class);
+        given(authorizationCode.getAuthModules()).willReturn("DataStore");
+        given(authorizationCode.getAuthenticationContextClassReference()).willReturn("urn:mace:incommon:iap:silver");
+        given(authorizationCode.getSessionId()).willReturn(null);
+        given(request.getToken(AuthorizationCode.class)).willReturn(authorizationCode);
+
+        // When
+        AccessToken token = tokenStore.createAccessToken("authorization_code", "exmple", "123-456-789", "owner-id",
+                "client-id", "http://a/b.com", singleton("open"), null, "qwerty", "some-claim", request);
+
+        // Then
+        assertThat(token.getTokenInfo().get("acr")).isEqualTo("urn:mace:incommon:iap:silver");
+        assertThat(token.getTokenInfo().get("authModules")).isEqualTo("DataStore");
+    }
+
+    @Test
+    public void whenRefreshTokenPresentAcrAndAmrGetAddedToAccessToken() throws Exception {
+        // Given
+        givenBaseProviderSettings();
+        given(utils.getConfirmationKey(request)).willReturn(null);
+
+        RefreshToken currentRefreshToken = mock(RefreshToken.class);
+        given(currentRefreshToken.getAuthModules()).willReturn("LDAP");
+        given(currentRefreshToken.getAuthenticationContextClassReference()).willReturn("urn:mace:incommon:iap:bronze");
+        given(request.getToken(RefreshToken.class)).willReturn(currentRefreshToken);
+
+        // When
+        AccessToken token = tokenStore.createAccessToken("refresh_token", "exmple", "123-456-789", "owner-id",
+                "client-id", "http://a/b.com", singleton("open"), null, "qwerty", "some-claim", request);
+
+        // Then
+        assertThat(token.getTokenInfo().get("acr")).isEqualTo("urn:mace:incommon:iap:bronze");
+        assertThat(token.getTokenInfo().get("authModules")).isEqualTo("LDAP");
+    }
+
+    @Test
+    public void whenRefreshTokenPresentItOverridesAuthorizationCodeAcrAndAmr() throws Exception {
+        // Given
+        givenBaseProviderSettings();
+        given(utils.getConfirmationKey(request)).willReturn(null);
+
+        AuthorizationCode authorizationCode = mock(AuthorizationCode.class);
+        given(authorizationCode.getAuthModules()).willReturn("DataStore");
+        given(authorizationCode.getAuthenticationContextClassReference()).willReturn("acr-from-code");
+        given(authorizationCode.getSessionId()).willReturn(null);
+        given(request.getToken(AuthorizationCode.class)).willReturn(authorizationCode);
+
+        RefreshToken currentRefreshToken = mock(RefreshToken.class);
+        given(currentRefreshToken.getAuthModules()).willReturn("LDAP");
+        given(currentRefreshToken.getAuthenticationContextClassReference()).willReturn("acr-from-refresh");
+        given(request.getToken(RefreshToken.class)).willReturn(currentRefreshToken);
+
+        // When
+        AccessToken token = tokenStore.createAccessToken("refresh_token", "exmple", "123-456-789", "owner-id",
+                "client-id", "http://a/b.com", singleton("open"), null, "qwerty", "some-claim", request);
+
+        // Then
+        assertThat(token.getTokenInfo().get("acr")).isEqualTo("acr-from-refresh");
+        assertThat(token.getTokenInfo().get("authModules")).isEqualTo("LDAP");
+    }
+
+    @Test
+    public void whenNoAcrOrAmrAvailableTheyAreNotAddedToAccessToken() throws Exception {
+        // Given
+        givenBaseProviderSettings();
+        given(utils.getConfirmationKey(request)).willReturn(null);
+
+        // When
+        AccessToken token = tokenStore.createAccessToken("client_credentials", "exmple", "123-456-789", "owner-id",
+                "client-id", "http://a/b.com", singleton("open"), null, "qwerty", "some-claim", request);
+
+        // Then
+        assertThat(token.getTokenInfo()).doesNotContainKey("acr");
+        assertThat(token.getTokenInfo()).doesNotContainKey("authModules");
+    }
+
+    private void givenBaseProviderSettings() throws Exception {
+        given(providerSettingsFactory.get(request)).willReturn(settings);
+        given(clientRegistrationStore.get("client-id", request)).willReturn(null);
+        given(request.getParameter("realm")).willReturn("/abc");
+        given(realmNormaliser.normalise("/abc")).willReturn("/def");
+        given(oAuth2UrisFactory.get(request)).willReturn(oAuth2Uris);
+        given(oAuth2Uris.getIssuer()).willReturn("some-issuer");
+        given(settings.getTokenSigningAlgorithm()).willReturn("HS256");
+        given(settings.getSupportedIDTokenSigningAlgorithms()).willReturn(singleton("HS256"));
+        given(settings.getTokenHmacSharedSecret()).willReturn("c2VjcmV0");
     }
 
 }


### PR DESCRIPTION
## Summary

This PR adds the authentication context class reference (`acr`) and the
authentication modules (`authModules`, i.e. the `amr` value) to the **stateless
JWT access token**.

Until now these claims were only available in the `id_token`, the
`/oauth2/userinfo` endpoint and the `/oauth2/tokeninfo` endpoint. The stateless
access token was assembled in `StatelessTokenStore.createAccessToken(...)` from
a **hard-coded claim set with no extension point**, so neither the OIDC Claims
Script nor a custom Scope Implementation Class could influence it. As a result,
PEPs / API gateways that need `acr`/`amr` were forced to make an extra
`/oauth2/tokeninfo` round-trip per request.

With this change the claims are written directly into the access token payload,
exactly the same way they are already written into the refresh token in
`createRefreshToken(...)`.

## Motivation

- Reported in [OpenAM Discussion #1027](https://github.com/OpenIdentityPlatform/OpenAM/discussions/1027).
- The stateless access token already carried `acr`/`amr` for the **refresh
  token** but not for the **access token** — an inconsistency inherited from the
  original ForgeRock code.
- Avoids an extra network round-trip to `/oauth2/tokeninfo` for downstream
  services that authorize on `acr`/`amr`.

## Changes

### OAuth2 (server)
- `StatelessTokenStore.createAccessToken(...)`:
  - After building the base `JwtClaimsSetBuilder`, extract `acr`
    (`getAuthenticationContextClassReference()`) and `authModules`
    (`getAuthModules()`) from:
    - the `AuthorizationCode` present in the request (authorization_code grant), and
    - the previous `RefreshToken` present in the request (refresh_token grant),
      which **overrides** the authorization-code values when present.
  - The `acr` and `authModules` claims are added **only when a value is
    available**, keeping the change additive and backward-compatible.
  - Reuses the existing `authCode` lookup (already read for the
    `realm_access.roles` logic); no new imports required — `ACR` and
    `AUTH_MODULES` constants were already imported.

### Documentation
- `admin-guide/chap-openid-connect.adoc`: the decoded stateless access token
  example now shows the `acr` and `authModules` claims, with a `NOTE` explaining
  that they appear only when the originating authorization code / refresh token
  carries them (e.g. omitted for the `client_credentials` grant).

### Tests
- `StatelessTokenStoreTest` (new tests):
  - `whenAuthorizationCodePresentAcrAndAmrGetAddedToAccessToken`
  - `whenRefreshTokenPresentAcrAndAmrGetAddedToAccessToken`
  - `whenRefreshTokenPresentItOverridesAuthorizationCodeAcrAndAmr`
  - `whenNoAcrOrAmrAvailableTheyAreNotAddedToAccessToken`
  - Shared mock setup extracted into `givenBaseProviderSettings()`.

## Behavioral / compatibility notes

- **Additive only.** When no authorization code or refresh token with `acr` /
  `authModules` is available (for example, the `client_credentials` grant), the
  claims are simply omitted — existing tokens are unaffected.
- **Consistent with refresh tokens.** The logic and claim names (`acr`,
  `authModules`) match `createRefreshToken(...)`.
- No configuration changes, no new scripts, no new provider settings.

## How to test

```bash
# Unit tests
mvn -pl openam-oauth2 test -Dtest=StatelessTokenStoreTest
```

Result: `Tests run: 6, Failures: 0, Errors: 0, Skipped: 0`.

Manual:
1. Configure an OAuth2/OIDC provider with **stateless** OAuth2 tokens enabled.
2. Obtain an access token via the `authorization_code` grant after
   authenticating through a chain that yields an `acr` / auth modules.
3. Decode the JWT access token (or call `/oauth2/tokeninfo`) and confirm the
   `acr` and `authModules` claims are present in the payload.
4. Refresh the token and confirm `acr` / `authModules` are preserved from the
   refresh token.

## Related

- Discussion: [OpenIdentityPlatform/OpenAM #1027](https://github.com/OpenIdentityPlatform/OpenAM/discussions/1027)

