### PR TITLE
Add OAuth2 Access Token Modification Script (`OAUTH2_ACCESS_TOKEN_MODIFICATION`)

### DIFF
--- a/openam-core/src/main/java/org/forgerock/openam/oauth2/OAuth2Constants.java
+++ b/openam-core/src/main/java/org/forgerock/openam/oauth2/OAuth2Constants.java
@@ -14,6 +14,7 @@
  * Copyright 2012-2016 ForgeRock AS.
  * Portions Copyrighted 2015 Nomura Research Institute, Ltd.
  * Portions Copyrighted 2018 Open Source Solution Technology Corporation
+ * Portions Copyright 2019-2026 3A Systems LLC.
  */
 
 package org.forgerock.openam.oauth2;
@@ -847,6 +848,8 @@ public class OAuth2Constants {
         public static final String SAVED_CONSENT_ATTRIBUTE = "forgerock-oauth2-provider-saved-consent-attribute";
         public static final String OIDC_CLAIMS_EXTENSION_SCRIPT =
                 "forgerock-oauth2-provider-oidc-claims-extension-script";
+        public static final String ACCESS_TOKEN_MODIFICATION_SCRIPT =
+                "forgerock-oauth2-provider-access-token-modification-script";
         public static final String JKWS_URI = "forgerock-oauth2-provider-jkws-uri";
         public static final String CREATED_TIMESTAMP_ATTRIBUTE_NAME =
                 "forgerock-oauth2-provider-created-attribute-name";
@@ -1109,6 +1112,8 @@ public class OAuth2Constants {
         public static final String CLAIMS = "claims";
         public static final String SESSION = "session";
         public static final String REQUESTED_CLAIMS = "requestedClaims";
+        public static final String ACCESS_TOKEN = "accessToken";
+        public static final String REQUEST_PROPERTIES = "requestProperties";
     }
 
     /**

--- a/openam-documentation/openam-doc-source/src/main/asciidoc/admin-guide/chap-manage-scripts.adoc
+++ b/openam-documentation/openam-doc-source/src/main/asciidoc/admin-guide/chap-manage-scripts.adoc
@@ -12,7 +12,7 @@
   information: "Portions copyright [year] [name of copyright owner]".
  
   Copyright 2017 ForgeRock AS.
-  Portions Copyright 2024 3A Systems LLC.
+  Portions Copyright 2024-2026 3A Systems LLC.
 ////
 
 :figure-caption!:
@@ -139,7 +139,7 @@ Create an OpenAM script as follows:
 script-file=/path/to/script-file
 language=JAVASCRIPT|GROOVY
 name=myScript
-context=AUTHENTICATION_SERVER_SIDE|AUTHENTICATION_CLIENT_SIDE|POLICY_CONDITION|OIDC_CLAIMS
+context=AUTHENTICATION_SERVER_SIDE|AUTHENTICATION_CLIENT_SIDE|POLICY_CONDITION|OIDC_CLAIMS|OAUTH2_ACCESS_TOKEN_MODIFICATION
 ----
 
 . Run the `ssoadm create-sub-cfg` command. The `--datafile` argument references the script configuration file you created in the previous step:

--- a/openam-documentation/openam-doc-source/src/main/asciidoc/admin-guide/chap-openid-connect.adoc
+++ b/openam-documentation/openam-doc-source/src/main/asciidoc/admin-guide/chap-openid-connect.adoc
@@ -12,7 +12,7 @@
   information: "Portions copyright [year] [name of copyright owner]".
  
   Copyright 2017 ForgeRock AS.
-  Portions Copyright 2024-2025 3A Systems LLC.
+  Portions Copyright 2024-2026 3A Systems LLC.
 ////
 
 :figure-caption!:
@@ -798,10 +798,22 @@ $ curl http://openam.example.com:8080/openam/oauth2/tokeninfo?access_token=eyAid
      "openid":"",
      "jti":"f8010f16-fba4-485e-84c5-c68e6296f21c",
      "token_type":"Bearer",
+     "acr":"urn:mace:incommon:iap:silver",
+     "authModules":"DataStore",
      "access_token":"eyAid...1knJDss",
      "profile":""
  }
 ----
++
+[NOTE]
+====
+The `acr` (Authentication Context Class Reference) and `authModules` claims are
+included in the stateless access token only when the originating authorization
+code or refresh token carries this information, for example when the access
+token is issued through the `authorization_code` or `refresh_token` grant. When
+no such data is available (for example, with the `client_credentials` grant),
+these claims are omitted.
+====
 
 ====
 

--- a/openam-documentation/openam-doc-source/src/main/asciidoc/dev-guide/chap-client-dev.adoc
+++ b/openam-documentation/openam-doc-source/src/main/asciidoc/dev-guide/chap-client-dev.adoc
@@ -8480,6 +8480,9 @@ a|`JAVASCRIPT`
 
 a|`OIDC_CLAIMS`
 a|`JAVASCRIPT`, `GROOVY`
+
+a|`OAUTH2_ACCESS_TOKEN_MODIFICATION`
+a|`JAVASCRIPT`, `GROOVY`
 |===
 +
 
@@ -8509,6 +8512,9 @@ Client-side scripts must be written in JavaScript.
 
 `OIDC_CLAIMS`::
 OIDC Claims
+
+`OAUTH2_ACCESS_TOKEN_MODIFICATION`::
+OAuth2 Access Token Modification
 
 ====
 

--- a/openam-documentation/openam-doc-source/src/main/asciidoc/dev-guide/chap-scripting.adoc
+++ b/openam-documentation/openam-doc-source/src/main/asciidoc/dev-guide/chap-scripting.adoc
@@ -12,7 +12,7 @@
   information: "Portions copyright [year] [name of copyright owner]".
  
   Copyright 2017 ForgeRock AS.
-  Portions Copyright 2024-2025 3A Systems LLC.
+  Portions Copyright 2024-2026 3A Systems LLC.
 ////
 
 :figure-caption!:
@@ -71,6 +71,12 @@ To see an example policy condition script, see xref:#sec-scripted-policy-conditi
 
 OIDC Claims::
 Scripts that gather and populate the claims in a request when issuing an ID token or making a request to the `userinfo` endpoint.
+
+OAuth2 Access Token Modification::
+Scripts that add, modify, or remove claims in a stateless (JWT) OAuth 2.0 access token or refresh token when it is issued.
+
++
+To see an example access token modification script, see xref:#scripting-api-access-token-modification["OAuth2 Access Token Modification API Functionality"].
 
 --
 OpenAM implements a configurable scripting engine for each of the context types that are executed on the server.
@@ -729,6 +735,91 @@ a|Contains requested claims if the `claims` query parameter is used in the reque
 }
 ----
 |===
+
+
+
+
+[#scripting-api-access-token-modification]
+==== OAuth2 Access Token Modification API Functionality
+
+This section covers functionality available when scripting OAuth 2.0 access token modification using the `OAUTH2_ACCESS_TOKEN_MODIFICATION` script context type.
+
+The script is executed when OpenAM issues a stateless (JWT) OAuth 2.0 access token or refresh token. Any claims the script adds, modifies, or removes are merged into the token payload before it is signed. This lets you embed custom claims (such as `acr`, `amr`, roles, or profile attributes) directly into the access token, without an additional call to the `/oauth2/tokeninfo` endpoint.
+
+[NOTE]
+======
+The script is only invoked when __Use Stateless Access & Refresh Tokens__ is enabled in the OAuth2 Provider service. Stateful tokens are opaque and do not carry claims.
+
+To preserve custom claims across the refresh cycle, the script runs both when issuing the access token and when issuing the refresh token.
+======
+
+[#scripted-api-access-token-modification-objects]
+.Access Token Modification Objects
+[cols="33%,22%,45%"]
+|===
+|Object |Type |Description
+
+a|`accessToken`
+a|`Class`
+a|A mutable view of the token being issued. Use the following methods to modify the token payload:
+
+* `accessToken.setField(String name, Object value)` - adds or overrides a claim.
+* `accessToken.getField(String name)` - reads a claim previously set by the script, or a read-only context value (for example `sub`, `realm`, `clientId`, `scope`, `grantType`, `acr`, `amr`, `tokenName`).
+* `accessToken.removeField(String name)` - removes a custom claim added by the script.
+
+ For more details, see the `org.forgerock.openam.oauth2.ScriptableAccessToken` class.
+
+a|`scopes`
+a|`Set<String>`
+a|Contains the set of scopes granted to the token. For example:
+
+[source, javascript]
+----
+[
+    "profile",
+    "openid"
+]
+----
+
+a|`identity`
+a|`Class`
+a|Contains a representation of the identity of the resource owner, when it can be resolved. May be `null` (for example, for the `client_credentials` grant).
+
+ For more details, see the `com.sun.identity.idm.AMIdentity` class in the link:../apidocs/index.html?com/sun/identity/idm/AMIdentity.html[OpenAM Javadoc, window=\_top].
+
+a|`session`
+a|`Class`
+a|Contains a representation of the user's session object if the request contained a valid session. May be `null`.
+
+ For more details, see the `com.iplanet.sso.SSOToken` class in the link:../apidocs/index.html?com/iplanet/sso/SSOToken.html[OpenAM Javadoc, window=\_top].
+
+a|`requestProperties`
+a|`Map<String, Object>`
+a|Contains selected properties of the OAuth 2.0 request, such as `clientId`, `realm`, and `grantType`.
+
+a|`logger`
+a|`Class`
+a|Contains the `OAuth2Provider` debug logger instance.
+
+ For more details, see the `com.sun.identity.shared.debug.Debug` class in the link:../apidocs/index.html?com/sun/identity/shared/debug/Debug.html[OpenAM Javadoc, window=\_top].
+|===
+
+The script does not need to return a value; changes applied to the `accessToken` object are merged into the issued token. For example, the following Groovy fragment copies the authentication context class reference into the token and adds a custom claim:
+
+[source, groovy]
+----
+def acr = accessToken.getField("acr")
+if (acr != null) {
+    accessToken.setField("acr", acr)
+}
+
+if (identity != null) {
+    def mail = identity.getAttribute("mail")
+    if (mail != null && !mail.isEmpty()) {
+        accessToken.setField("email", mail.iterator().next())
+    }
+}
+----
 
 
 

--- a/openam-documentation/openam-doc-source/src/main/asciidoc/reference/chap-config-ref.adoc
+++ b/openam-documentation/openam-doc-source/src/main/asciidoc/reference/chap-config-ref.adoc
@@ -2395,6 +2395,21 @@ Default: `OIDC Claims Script`
 +
 `ssoadm` attribute: `forgerock-oauth2-provider-oidc-claims-extension-script`
 
+OAuth2 Access Token Modification Script::
+The script that is run when issuing a stateless (JWT) OAuth 2.0 access token or refresh token. The script can add, modify, or remove claims in the token payload, allowing custom claims (such as `acr`, `amr`, roles, or profile attributes) to be embedded directly in the access token.
+
++
+The script has access to a mutable view of the token (`accessToken`), the granted scopes, the resource owner's identity, the user's session (if available), and selected request properties.
+
++
+This script is only run when stateless tokens are enabled. For more information on scripting, see xref:../dev-guide/chap-scripting.adoc#scripting-api-access-token-modification["OAuth2 Access Token Modification API Functionality"] in the __Developer's Guide__.
+
++
+Default: `OAuth2 Access Token Modification Script`
+
++
+`ssoadm` attribute: `forgerock-oauth2-provider-access-token-modification-script`
+
 Response Type Plugins::
 List of plugins that handle the valid `response_type` values. OAuth 2.0 clients pass response types as parameters to the OAuth 2.0 Authorization endpoint (`/oauth2/authorize`) to indicate which grant type is requested from the provider. For example, the client passes `code` when requesting an authorization code, and `token` when requesting an access token.
 
@@ -3640,6 +3655,9 @@ Client-side Authentication
 
 `OIDC_CLAIMS`::
 OIDC Claims
+
+`OAUTH2_ACCESS_TOKEN_MODIFICATION`::
+OAuth2 Access Token Modification
 
 ====
 +

--- a/openam-i18n/src/main/resources/api-descriptor/ScriptResource.properties
+++ b/openam-i18n/src/main/resources/api-descriptor/ScriptResource.properties
@@ -12,7 +12,7 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2016 ForgeRock AS.
-#
+# Portions Copyright 2026 3A Systems LLC.
 #
 
 ########################################################################################################################
@@ -90,7 +90,8 @@ context.description=The context type of the script. Supported values are: \
   POLICY_CONDITION : Policy Condition  \
   AUTHENTICATION_SERVER_SIDE : Server-side Authentication  \
   AUTHENTICATION_CLIENT_SIDE : Client-side Authentication - Note Client-side scripts must be written in JavaScript \
-  OIDC_CLAIMS : OIDC Claims
+  OIDC_CLAIMS : OIDC Claims \
+  OAUTH2_ACCESS_TOKEN_MODIFICATION : OAuth2 Access Token Modification
 createdBy.title=Created by
 createdBy.description=A string containing the universal identifier DN of the subject that created the script
 creationDate.title=Creation date

--- a/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/OAuth2AccessTokenModifier.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/OAuth2AccessTokenModifier.java
@@ -1,0 +1,190 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems LLC.
+ */
+
+package org.forgerock.openam.oauth2;
+
+import static org.forgerock.openam.scripting.ScriptConstants.EMPTY_SCRIPT_SELECTION;
+import static org.forgerock.openam.scripting.ScriptConstants.OAUTH2_ACCESS_TOKEN_MODIFICATION_NAME;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import javax.script.Bindings;
+import javax.script.SimpleBindings;
+
+import org.forgerock.oauth2.core.OAuth2Request;
+import org.forgerock.openam.scripting.ScriptEvaluator;
+import org.forgerock.openam.scripting.ScriptObject;
+import org.forgerock.openam.scripting.service.ScriptConfiguration;
+import org.forgerock.openam.scripting.service.ScriptingServiceFactory;
+import org.forgerock.openam.utils.OpenAMSettingsImpl;
+import org.forgerock.openam.utils.StringUtils;
+
+import com.iplanet.sso.SSOException;
+import com.iplanet.sso.SSOToken;
+import com.iplanet.sso.SSOTokenManager;
+import com.sun.identity.idm.AMIdentity;
+import com.sun.identity.shared.debug.Debug;
+import com.sun.identity.sm.SMSException;
+
+/**
+ * Evaluates the configured OAuth2 Access Token Modification script (script context
+ * {@code OAUTH2_ACCESS_TOKEN_MODIFICATION}) and merges any additional claims into the stateless
+ * JWT access/refresh token being issued.
+ *
+ * <p>The script is provided with the following bindings: {@code accessToken}, {@code scopes},
+ * {@code identity}, {@code session}, {@code requestProperties} and {@code logger}.</p>
+ */
+@Singleton
+public class OAuth2AccessTokenModifier {
+
+    private final ScriptEvaluator scriptEvaluator;
+    private final ScriptingServiceFactory scriptingServiceFactory;
+    private final IdentityManager identityManager;
+    private final Debug logger;
+
+    /**
+     * Constructs a new {@code OAuth2AccessTokenModifier}.
+     *
+     * @param scriptEvaluator The {@link ScriptEvaluator} bound to the access token modification context.
+     * @param scriptingServiceFactory The {@link ScriptingServiceFactory} used to load script configurations.
+     * @param identityManager The {@link IdentityManager} used to resolve the resource owner identity.
+     * @param logger The OAuth2 provider debug logger.
+     */
+    @Inject
+    public OAuth2AccessTokenModifier(
+            @Named(OAUTH2_ACCESS_TOKEN_MODIFICATION_NAME) ScriptEvaluator scriptEvaluator,
+            ScriptingServiceFactory scriptingServiceFactory,
+            IdentityManager identityManager,
+            @Named(OAuth2Constants.DEBUG_LOG_NAME) Debug logger) {
+        this.scriptEvaluator = scriptEvaluator;
+        this.scriptingServiceFactory = scriptingServiceFactory;
+        this.identityManager = identityManager;
+        this.logger = logger;
+    }
+
+    /**
+     * Runs the configured OAuth2 Access Token Modification script (if any) and returns the additional
+     * claims to be merged into the token being issued. If no script is configured, or the script
+     * fails, an empty map is returned and the token is issued unmodified.
+     *
+     * @param request The current OAuth2 request.
+     * @param realm The realm the token is issued in.
+     * @param resourceOwnerId The resource owner id (subject) of the token.
+     * @param clientId The client id (audience) of the token.
+     * @param scope The scopes granted to the token.
+     * @param contextValues Read-only context values exposed to the script via {@code accessToken.getField()}.
+     * @return A map of additional claims to merge into the token. Never {@code null}.
+     */
+    public Map<String, Object> getModifiedClaims(OAuth2Request request, String realm, String resourceOwnerId,
+            String clientId, Set<String> scope, Map<String, Object> contextValues) {
+
+        Map<String, Object> result = new HashMap<>();
+        try {
+            ScriptObject script = getModificationScript(realm);
+            if (script == null || StringUtils.isBlank(script.getScript())) {
+                return result;
+            }
+
+            ScriptableAccessToken accessToken = new ScriptableAccessToken(contextValues);
+
+            Bindings bindings = new SimpleBindings();
+            bindings.put(OAuth2Constants.ScriptParams.ACCESS_TOKEN, accessToken);
+            bindings.put(OAuth2Constants.ScriptParams.SCOPES,
+                    scope == null ? new HashSet<String>() : new HashSet<>(scope));
+            bindings.put(OAuth2Constants.ScriptParams.IDENTITY, getIdentity(resourceOwnerId, realm));
+            bindings.put(OAuth2Constants.ScriptParams.SESSION, getSession(request));
+            bindings.put(OAuth2Constants.ScriptParams.REQUEST_PROPERTIES,
+                    buildRequestProperties(request, clientId, realm));
+            bindings.put(OAuth2Constants.ScriptParams.LOGGER, logger);
+
+            scriptEvaluator.evaluateScript(script, bindings);
+
+            result.putAll(accessToken.getFields());
+        } catch (Exception e) {
+            logger.error("Error running OAuth2 access token modification script", e);
+        }
+        return result;
+    }
+
+    private ScriptObject getModificationScript(String realm) {
+        OpenAMSettingsImpl settings = new OpenAMSettingsImpl(OAuth2Constants.OAuth2ProviderService.NAME,
+                OAuth2Constants.OAuth2ProviderService.VERSION);
+        try {
+            String scriptId = settings.getStringSetting(realm,
+                    OAuth2Constants.OAuth2ProviderService.ACCESS_TOKEN_MODIFICATION_SCRIPT);
+            if (StringUtils.isBlank(scriptId) || EMPTY_SCRIPT_SELECTION.equals(scriptId)) {
+                return null;
+            }
+            ScriptConfiguration config = scriptingServiceFactory.create(realm).get(scriptId);
+            return new ScriptObject(config.getName(), config.getScript(), config.getLanguage());
+        } catch (org.forgerock.openam.scripting.ScriptException | SSOException | SMSException e) {
+            logger.message("OAuth2 access token modification script not configured or unavailable", e);
+            return null;
+        }
+    }
+
+    private AMIdentity getIdentity(String resourceOwnerId, String realm) {
+        if (StringUtils.isBlank(resourceOwnerId)) {
+            return null;
+        }
+        try {
+            return identityManager.getResourceOwnerIdentity(resourceOwnerId, realm);
+        } catch (Exception e) {
+            logger.message("Unable to resolve resource owner identity for access token modification script", e);
+            return null;
+        }
+    }
+
+    private SSOToken getSession(OAuth2Request request) {
+        if (request == null) {
+            return null;
+        }
+        try {
+            String sessionId = request.getSession();
+            if (StringUtils.isNotBlank(sessionId)) {
+                return SSOTokenManager.getInstance().createSSOToken(sessionId);
+            }
+        } catch (Exception e) {
+            logger.message("Unable to resolve session for access token modification script", e);
+        }
+        return null;
+    }
+
+    private Map<String, Object> buildRequestProperties(OAuth2Request request, String clientId, String realm) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("clientId", clientId);
+        properties.put("realm", realm);
+        if (request != null) {
+            try {
+                Object grantType = request.getParameter(OAuth2Constants.Params.GRANT_TYPE);
+                if (grantType != null) {
+                    properties.put("grantType", grantType);
+                }
+            } catch (Exception e) {
+                // Ignore - request parameters are best-effort.
+            }
+        }
+        return properties;
+    }
+}
+
+

--- a/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/ScriptableAccessToken.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/ScriptableAccessToken.java
@@ -1,0 +1,114 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems LLC.
+ */
+
+package org.forgerock.openam.oauth2;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A mutable view of an OAuth2 access/refresh token that is exposed to the OAuth2 Access Token
+ * Modification script (script context {@code OAUTH2_ACCESS_TOKEN_MODIFICATION}).
+ * <p>
+ * The script can read contextual information about the token being issued and add, override or
+ * remove claims that will be merged into the resulting stateless JWT.
+ */
+public class ScriptableAccessToken {
+
+    /** Read-only context values about the token being issued (sub, scope, realm, ...). */
+    private final Map<String, Object> info;
+    /** Claims added or overridden by the script. */
+    private final Map<String, Object> fields = new HashMap<>();
+    /** Claim names the script requested to be removed. */
+    private final Set<String> removedFields = new HashSet<>();
+
+    /**
+     * Constructs a new {@code ScriptableAccessToken}.
+     *
+     * @param info the read-only context values exposed to the script via {@link #getField(String)}.
+     */
+    public ScriptableAccessToken(Map<String, Object> info) {
+        this.info = info == null ? new HashMap<String, Object>() : new HashMap<>(info);
+    }
+
+    /**
+     * Adds or overrides a claim on the token being issued.
+     *
+     * @param name the claim name.
+     * @param value the claim value.
+     */
+    public void setField(String name, Object value) {
+        if (name == null) {
+            return;
+        }
+        fields.put(name, value);
+        removedFields.remove(name);
+    }
+
+    /**
+     * Returns the value of a claim previously set by the script, or, if not set, the value of the
+     * matching read-only context value.
+     *
+     * @param name the claim/context name.
+     * @return the value, or {@code null} if not present.
+     */
+    public Object getField(String name) {
+        if (fields.containsKey(name)) {
+            return fields.get(name);
+        }
+        return info.get(name);
+    }
+
+    /**
+     * Requests removal of a claim from the token being issued. Note that only custom claims added
+     * by the script (or non-protected claims) can be removed; protected/standard JWT claims are
+     * preserved.
+     *
+     * @param name the claim name to remove.
+     */
+    public void removeField(String name) {
+        if (name == null) {
+            return;
+        }
+        fields.remove(name);
+        removedFields.add(name);
+    }
+
+    /**
+     * @return the read-only context values exposed to the script.
+     */
+    public Map<String, Object> getInfo() {
+        return Collections.unmodifiableMap(info);
+    }
+
+    /**
+     * @return the claims added or overridden by the script.
+     */
+    public Map<String, Object> getFields() {
+        return fields;
+    }
+
+    /**
+     * @return the names of the claims the script requested to be removed.
+     */
+    public Set<String> getRemovedFields() {
+        return removedFields;
+    }
+}
+

--- a/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/StatelessTokenStore.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/StatelessTokenStore.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions copyright 2025 3A Systems LLC.
+ * Portions copyright 2020-2026 3A Systems LLC.
  */
 
 package org.forgerock.openam.oauth2;
@@ -234,8 +234,29 @@ public class StatelessTokenStore implements TokenStore {
                 .claim(AUDIT_TRACKING_ID, UUID.randomUUID().toString())
                 .claim(AUTH_GRANT_ID, refreshToken != null ? refreshToken.getAuthGrantId() : UUID.randomUUID().toString())
                 .claim(AUTH_TIME, authTime);
-        
-        
+
+        // Propagate authentication context (acr) and authentication modules (amr) into the
+        // stateless JWT access token, mirroring the behaviour of createRefreshToken. The values
+        // are sourced from the AuthorizationCode (authorization_code grant) or from the previous
+        // RefreshToken (refresh_token grant), so PEPs/API gateways can read acr/amr directly from
+        // the access token payload without an extra /oauth2/tokeninfo round-trip.
+        String authModules = null;
+        String acr = null;
+        if (authCode != null) {
+            authModules = authCode.getAuthModules();
+            acr = authCode.getAuthenticationContextClassReference();
+        }
+        RefreshToken currentRefreshToken = request.getToken(RefreshToken.class);
+        if (currentRefreshToken != null) {
+            authModules = currentRefreshToken.getAuthModules();
+            acr = currentRefreshToken.getAuthenticationContextClassReference();
+        }
+        if (authModules != null) {
+            claimsSetBuilder.claim(AUTH_MODULES, authModules);
+        }
+        if (acr != null) {
+            claimsSetBuilder.claim(ACR, acr);
+        }
 
         JsonValue confirmationJwk = utils.getConfirmationKey(request);
         if (confirmationJwk != null) {

--- a/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/StatelessTokenStore.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/StatelessTokenStore.java
@@ -117,6 +117,7 @@ public class StatelessTokenStore implements TokenStore {
     private final CTSPersistentStore cts;
     private final TokenAdapter<StatelessTokenMetadata> tokenAdapter;
     private final OAuth2Utils utils;
+    private final OAuth2AccessTokenModifier accessTokenModifier;
 
 
     /**
@@ -133,13 +134,15 @@ public class StatelessTokenStore implements TokenStore {
      * @param cts An instance of the CTSPersistentStoreImpl
      * @param tokenAdapter An instance of the StatelessTokenCtsAdapter
      * @param utils OAuth2 utilities
+     * @param accessTokenModifier Runs the OAuth2 Access Token Modification script.
      */
     @Inject
     public StatelessTokenStore(StatefulTokenStore statefulTokenStore, JwtBuilderFactory jwtBuilder,
             OAuth2ProviderSettingsFactory providerSettingsFactory, @Named(OAuth2Constants.DEBUG_LOG_NAME) Debug logger,
             OpenIdConnectClientRegistrationStore clientRegistrationStore, RealmNormaliser realmNormaliser,
             OAuth2UrisFactory oAuth2UrisFactory, Blacklist<Blacklistable> tokenBlacklist,
-            CTSPersistentStore cts, TokenAdapter<StatelessTokenMetadata> tokenAdapter, OAuth2Utils utils) {
+            CTSPersistentStore cts, TokenAdapter<StatelessTokenMetadata> tokenAdapter, OAuth2Utils utils,
+            OAuth2AccessTokenModifier accessTokenModifier) {
         this.statefulTokenStore = statefulTokenStore;
         this.jwtBuilder = jwtBuilder;
         this.providerSettingsFactory = providerSettingsFactory;
@@ -151,6 +154,7 @@ public class StatelessTokenStore implements TokenStore {
         this.cts = cts;
         this.tokenAdapter = tokenAdapter;
         this.utils = utils;
+        this.accessTokenModifier = accessTokenModifier;
     }
 
     @Override
@@ -256,6 +260,27 @@ public class StatelessTokenStore implements TokenStore {
         }
         if (acr != null) {
             claimsSetBuilder.claim(ACR, acr);
+        }
+
+        // Run the configured OAuth2 Access Token Modification script (script context
+        // OAUTH2_ACCESS_TOKEN_MODIFICATION) and merge any returned claims into the access token.
+        Map<String, Object> accessTokenContext = new HashMap<>();
+        accessTokenContext.put(TOKEN_NAME, OAUTH_ACCESS_TOKEN);
+        accessTokenContext.put("sub", resourceOwnerId);
+        accessTokenContext.put(REALM, realm);
+        accessTokenContext.put("clientId", clientId);
+        accessTokenContext.put(SCOPE, scope);
+        accessTokenContext.put(GRANT_TYPE, grantType);
+        if (acr != null) {
+            accessTokenContext.put(ACR, acr);
+        }
+        if (authModules != null) {
+            accessTokenContext.put("amr", authModules);
+        }
+        Map<String, Object> modifiedClaims = accessTokenModifier.getModifiedClaims(request, realm, resourceOwnerId,
+                clientId, scope, accessTokenContext);
+        for (Map.Entry<String, Object> entry : modifiedClaims.entrySet()) {
+            claimsSetBuilder.claim(entry.getKey(), entry.getValue());
         }
 
         JsonValue confirmationJwk = utils.getConfirmationKey(request);
@@ -534,6 +559,29 @@ public class StatelessTokenStore implements TokenStore {
         if (!StringUtils.isBlank(validatedClaims)) {
             claimsSetBuilder.claim(CLAIMS, validatedClaims);
         }
+
+        // Run the configured OAuth2 Access Token Modification script (script context
+        // OAUTH2_ACCESS_TOKEN_MODIFICATION) and merge any returned claims into the refresh token, so
+        // that custom claims survive the refresh cycle.
+        Map<String, Object> refreshTokenContext = new HashMap<>();
+        refreshTokenContext.put(TOKEN_NAME, OAUTH_REFRESH_TOKEN);
+        refreshTokenContext.put("sub", resourceOwnerId);
+        refreshTokenContext.put(REALM, realm);
+        refreshTokenContext.put("clientId", clientId);
+        refreshTokenContext.put(SCOPE, scope);
+        refreshTokenContext.put(GRANT_TYPE, grantType);
+        if (acr != null) {
+            refreshTokenContext.put(ACR, acr);
+        }
+        if (authModules != null) {
+            refreshTokenContext.put("amr", authModules);
+        }
+        Map<String, Object> modifiedRefreshClaims = accessTokenModifier.getModifiedClaims(request, realm,
+                resourceOwnerId, clientId, scope, refreshTokenContext);
+        for (Map.Entry<String, Object> entry : modifiedRefreshClaims.entrySet()) {
+            claimsSetBuilder.claim(entry.getKey(), entry.getValue());
+        }
+
         JwsAlgorithm signingAlgorithm = getSigningAlgorithm(request);
         CompressionAlgorithm compressionAlgorithm = getCompressionAlgorithm(request);
         SignedJwt jwt = jwtBuilder.jws(getTokenSigningHandler(request, signingAlgorithm))

--- a/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/guice/OAuth2GuiceModule.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/guice/OAuth2GuiceModule.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
- * Portions copyright 2025 3A Systems LLC.
+ * Portions copyright 2025-2026 3A Systems LLC.
  */
 package org.forgerock.openam.oauth2.guice;
 
@@ -117,6 +117,7 @@ import org.forgerock.openam.oauth2.StatefulTokenStore;
 import org.forgerock.openam.oauth2.StatelessCheck;
 import org.forgerock.openam.oauth2.StatelessTokenCtsAdapter;
 import org.forgerock.openam.oauth2.StatelessTokenMetadata;
+import org.forgerock.openam.oauth2.OAuth2AccessTokenModifier;
 import org.forgerock.openam.oauth2.StatelessTokenStore;
 import org.forgerock.openam.oauth2.resources.OpenAMResourceSetStore;
 import org.forgerock.openam.oauth2.resources.ResourceSetRegistrationEndpoint;
@@ -345,13 +346,13 @@ public class OAuth2GuiceModule extends AbstractModule {
             ClientAuthenticationFailureFactory failureFactory, JwtBuilderFactory jwtBuilder,
             Blacklist<Blacklistable> tokenBlacklist, CTSPersistentStore cts,
             TokenAdapter<StatelessTokenMetadata> tokenAdapter, RecoveryCodeGenerator recoveryCodeGenerator,
-            OAuth2Utils utils) {
+            OAuth2Utils utils, OAuth2AccessTokenModifier accessTokenModifier) {
         StatefulTokenStore realmAgnosticStatefulTokenStore = new RealmAgnosticStatefulTokenStore(oauthTokenStore,
                 providerSettingsFactory, oauth2UrisFactory, clientRegistrationStore, realmNormaliser, ssoTokenManager,
                 cookieExtractor, auditLogger, debug, secureRandom, failureFactory, recoveryCodeGenerator, utils);
         StatelessTokenStore realmAgnosticStatelessTokenStore = new RealmAgnosticStatelessTokenStore(
                 realmAgnosticStatefulTokenStore, jwtBuilder, providerSettingsFactory, debug, clientRegistrationStore,
-                realmNormaliser, oauth2UrisFactory, tokenBlacklist, cts, tokenAdapter, utils);
+                realmNormaliser, oauth2UrisFactory, tokenBlacklist, cts, tokenAdapter, utils, accessTokenModifier);
         return new OpenAMTokenStore(realmAgnosticStatefulTokenStore,
                 realmAgnosticStatelessTokenStore, new DefaultStatelessCheck(providerSettingsFactory));
     }
@@ -424,9 +425,10 @@ public class OAuth2GuiceModule extends AbstractModule {
                 OAuth2ProviderSettingsFactory providerSettingsFactory, Debug logger,
                 OpenIdConnectClientRegistrationStore clientRegistrationStore, RealmNormaliser realmNormaliser,
                 OAuth2UrisFactory oAuth2UrisFactory, Blacklist<Blacklistable> tokenBlacklist,
-                CTSPersistentStore cts, TokenAdapter<StatelessTokenMetadata> tokenAdapter, OAuth2Utils utils) {
+                CTSPersistentStore cts, TokenAdapter<StatelessTokenMetadata> tokenAdapter, OAuth2Utils utils,
+                OAuth2AccessTokenModifier accessTokenModifier) {
             super(statefulTokenStore, jwtBuilder, providerSettingsFactory, logger, clientRegistrationStore,
-                    realmNormaliser, oAuth2UrisFactory, tokenBlacklist, cts, tokenAdapter, utils);
+                    realmNormaliser, oAuth2UrisFactory, tokenBlacklist, cts, tokenAdapter, utils, accessTokenModifier);
         }
 
         @Override

--- a/openam-oauth2/src/main/resources/OAuth2Provider.properties
+++ b/openam-oauth2/src/main/resources/OAuth2Provider.properties
@@ -24,6 +24,7 @@
 
 #
 # Portions Copyrighted 2014-2016 Nomura Research Institute, Ltd.
+# Portions Copyright 2026 3A Systems LLC.
 #
 
 forgerock-oauth2-provider-description=OAuth2 Provider
@@ -91,6 +92,11 @@ a104aa.help=This is a script that will be run, when using an implementation of t
   the access token, the user's session (if available), the user's identity.
 a104ab=OIDC Claims Script Type
 a104ab.help=This is the language of the OIDC claims script.
+a104ac=OAuth2 Access Token Modification Script
+a104ac.help=This is a script that will be run when issuing a stateless (JWT) OAuth2 access token or refresh \
+  token, allowing additional claims to be added to, or existing claims to be modified or removed from, the token \
+  payload. The script has access to the granted scopes, the user's identity, the user's session (if available), \
+  the request properties and a mutable view of the access token.
 scriptGroovyChoice=Groovy
 scriptJavaScriptChoice=JavaScript
 a105=Response Type Plugins

--- a/openam-oauth2/src/main/resources/OAuth2Provider.section.properties
+++ b/openam-oauth2/src/main/resources/OAuth2Provider.section.properties
@@ -12,7 +12,7 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2016 ForgeRock AS.
-#
+# Portions Copyright 2026 3A Systems LLC.
 
 coreOAuth2Config=statelessTokensEnabled
 coreOAuth2Config=forgerock-oauth2-provider-authorization-code-lifetime
@@ -47,6 +47,7 @@ coreOIDCConfig=supportedIDTokenEncryptionAlgorithms
 coreOIDCConfig=supportedIDTokenEncryptionMethods
 coreOIDCConfig=forgerock-oauth2-provider-supported-claims
 coreOIDCConfig=forgerock-oauth2-provider-oidc-claims-extension-script
+coreOIDCConfig=forgerock-oauth2-provider-access-token-modification-script
 
 advancedOIDCConfig=storeOpsTokens
 advancedOIDCConfig=forgerock-oauth2-provider-amr-mappings

--- a/openam-oauth2/src/main/resources/OAuth2Provider.xml
+++ b/openam-oauth2/src/main/resources/OAuth2Provider.xml
@@ -17,6 +17,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems LLC.
  */
 -->
 
@@ -25,7 +26,7 @@
         <Schema
                 serviceHierarchy="/DSAMEConfig/ForgerockOAuth2ProviderService"
                 i18nFileName="OAuth2Provider"
-                revisionNumber="1"
+                revisionNumber="2"
                 i18nKey="forgerock-oauth2-provider-description"
                 resourceName="oauth-oidc">
             <Global>
@@ -185,6 +186,27 @@
                     </ChoiceValues>
                     <DefaultValues>
                         <Value>@GlobalOidcClaimsScriptId@</Value>
+                    </DefaultValues>
+                </AttributeSchema>
+
+                <AttributeSchema name="forgerock-oauth2-provider-access-token-modification-script"
+                                 type="single_choice"
+                                 uitype="scriptSelect"
+                                 propertiesViewBeanURL="../XUI/%23realms/{0}/scripts/edit/{1}"
+                                 syntax="string"
+                                 i18nKey="a104ac"
+                                 resourceName="accessTokenModificationScript"
+                                 order="85">
+                    <ChoiceValues>
+                        <ChoiceValuesClassName className="org.forgerock.openam.scripting.service.ScriptChoiceValues">
+                            <AttributeValuePair>
+                                <Attribute name="ContextId"/>
+                                <Value>OAUTH2_ACCESS_TOKEN_MODIFICATION</Value>
+                            </AttributeValuePair>
+                        </ChoiceValuesClassName>
+                    </ChoiceValues>
+                    <DefaultValues>
+                        <Value>@GlobalAccessTokenModificationScriptId@</Value>
                     </DefaultValues>
                 </AttributeSchema>
 

--- a/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/AccessTokenModificationTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/AccessTokenModificationTest.java
@@ -1,0 +1,159 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems LLC.
+ */
+
+package org.forgerock.openam.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.openam.utils.CollectionUtils.asSet;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.iplanet.sso.SSOToken;
+import com.sun.identity.idm.AMIdentity;
+import com.sun.identity.shared.debug.Debug;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.script.Bindings;
+import javax.script.SimpleBindings;
+import org.codehaus.groovy.jsr223.GroovyScriptEngineFactory;
+import org.forgerock.openam.scripting.ScriptEvaluator;
+import org.forgerock.openam.scripting.ScriptObject;
+import org.forgerock.openam.scripting.StandardScriptEngineManager;
+import org.forgerock.openam.scripting.StandardScriptEvaluator;
+import org.forgerock.openam.scripting.SupportedScriptingLanguage;
+import org.forgerock.openam.utils.IOUtils;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the default OAuth2 Access Token Modification script
+ * ({@code access-token-modification.groovy}) by evaluating it through the scripting engine,
+ * mirroring {@link org.forgerock.openam.openidconnect.OidcClaimsExtensionTest} for the OIDC
+ * claims script.
+ */
+public class AccessTokenModificationTest {
+
+    private ScriptObject script;
+    private Debug logger;
+    private SSOToken ssoToken;
+    private AMIdentity identity;
+
+    private ScriptEvaluator scriptEvaluator;
+
+    @BeforeClass
+    public void setupScript() throws Exception {
+        String rawScript = IOUtils.readStream(
+                this.getClass().getClassLoader().getResourceAsStream("access-token-modification.groovy"));
+        SupportedScriptingLanguage scriptType = SupportedScriptingLanguage.GROOVY;
+
+        this.script = new ScriptObject("access-token-modification-script", rawScript, scriptType, null);
+
+        StandardScriptEngineManager scriptEngineManager = new StandardScriptEngineManager();
+        scriptEngineManager.registerEngineName(SupportedScriptingLanguage.GROOVY_ENGINE_NAME,
+                new GroovyScriptEngineFactory());
+        scriptEvaluator = new StandardScriptEvaluator(scriptEngineManager);
+    }
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        this.logger = mock(Debug.class);
+        this.ssoToken = mock(SSOToken.class);
+        this.identity = mock(AMIdentity.class);
+    }
+
+    @Test
+    public void propagatesAcrAndAmrFromContext() throws Exception {
+        // Given
+        Map<String, Object> context = new HashMap<>();
+        context.put("acr", "urn:mace:incommon:iap:silver");
+        context.put("amr", "pwd");
+        ScriptableAccessToken accessToken = new ScriptableAccessToken(context);
+        Bindings variables = testBindings(accessToken, asSet("openid", "profile"));
+
+        // When
+        scriptEvaluator.evaluateScript(script, variables);
+
+        // Then
+        assertThat(accessToken.getFields())
+                .containsEntry("acr", "urn:mace:incommon:iap:silver")
+                .containsEntry("amr", "pwd");
+        assertThat(accessToken.getRemovedFields()).isEmpty();
+    }
+
+    @Test
+    public void doesNotAddClaimsWhenAcrAndAmrAreAbsent() throws Exception {
+        // Given
+        ScriptableAccessToken accessToken = new ScriptableAccessToken(null);
+        Bindings variables = testBindings(accessToken, asSet("openid"));
+
+        // When
+        scriptEvaluator.evaluateScript(script, variables);
+
+        // Then
+        assertThat(accessToken.getFields()).isEmpty();
+        assertThat(accessToken.getRemovedFields()).isEmpty();
+    }
+
+    @Test
+    public void logsExecutionWhenMessageLoggingEnabled() throws Exception {
+        // Given
+        when(logger.messageEnabled()).thenReturn(true);
+        ScriptableAccessToken accessToken = new ScriptableAccessToken(null);
+        Bindings variables = testBindings(accessToken, asSet("openid", "profile"));
+
+        // When
+        scriptEvaluator.evaluateScript(script, variables);
+
+        // Then
+        verify(logger).message(anyString());
+    }
+
+    @Test
+    public void doesNotLogWhenMessageLoggingDisabled() throws Exception {
+        // Given
+        when(logger.messageEnabled()).thenReturn(false);
+        ScriptableAccessToken accessToken = new ScriptableAccessToken(null);
+        Bindings variables = testBindings(accessToken, asSet("openid"));
+
+        // When
+        scriptEvaluator.evaluateScript(script, variables);
+
+        // Then
+        verify(logger, never()).message(anyString());
+    }
+
+    private Bindings testBindings(ScriptableAccessToken accessToken, Set<String> scopes) {
+        Map<String, Object> requestProperties = new HashMap<>();
+        requestProperties.put("clientId", "myClient");
+        requestProperties.put("realm", "/");
+        requestProperties.put("grantType", "authorization_code");
+
+        Bindings scriptVariables = new SimpleBindings();
+        scriptVariables.put("logger", logger);
+        scriptVariables.put("accessToken", accessToken);
+        scriptVariables.put("session", ssoToken);
+        scriptVariables.put("identity", identity);
+        scriptVariables.put("scopes", scopes);
+        scriptVariables.put("requestProperties", requestProperties);
+        return scriptVariables;
+    }
+}
+

--- a/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/ScriptableAccessTokenTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/ScriptableAccessTokenTest.java
@@ -1,0 +1,117 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems LLC.
+ */
+package org.forgerock.openam.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for {@link ScriptableAccessToken}.
+ */
+public class ScriptableAccessTokenTest {
+
+    @Test
+    public void setFieldExposesValueAndCollectsIt() {
+        // Given
+        ScriptableAccessToken accessToken = new ScriptableAccessToken(null);
+
+        // When
+        accessToken.setField("department", "engineering");
+
+        // Then
+        assertThat(accessToken.getField("department")).isEqualTo("engineering");
+        assertThat(accessToken.getFields()).containsEntry("department", "engineering");
+    }
+
+    @Test
+    public void getFieldFallsBackToReadOnlyContext() {
+        // Given
+        Map<String, Object> context = new HashMap<>();
+        context.put("sub", "owner-id");
+        context.put("realm", "/");
+        ScriptableAccessToken accessToken = new ScriptableAccessToken(context);
+
+        // When / Then
+        assertThat(accessToken.getField("sub")).isEqualTo("owner-id");
+        assertThat(accessToken.getField("realm")).isEqualTo("/");
+        // Context values are not treated as script modifications.
+        assertThat(accessToken.getFields()).doesNotContainKey("sub");
+    }
+
+    @Test
+    public void setFieldOverridesContextValueWhenReadBack() {
+        // Given
+        Map<String, Object> context = new HashMap<>();
+        context.put("sub", "owner-id");
+        ScriptableAccessToken accessToken = new ScriptableAccessToken(context);
+
+        // When
+        accessToken.setField("sub", "overridden");
+
+        // Then
+        assertThat(accessToken.getField("sub")).isEqualTo("overridden");
+        assertThat(accessToken.getFields()).containsEntry("sub", "overridden");
+    }
+
+    @Test
+    public void removeFieldDropsModificationAndRecordsRemoval() {
+        // Given
+        ScriptableAccessToken accessToken = new ScriptableAccessToken(null);
+        accessToken.setField("department", "engineering");
+
+        // When
+        accessToken.removeField("department");
+
+        // Then
+        assertThat(accessToken.getFields()).doesNotContainKey("department");
+        assertThat(accessToken.getRemovedFields()).contains("department");
+    }
+
+    @Test
+    public void infoMapIsImmutable() {
+        // Given
+        Map<String, Object> context = new HashMap<>();
+        context.put("realm", "/");
+        ScriptableAccessToken accessToken = new ScriptableAccessToken(context);
+
+        // When / Then
+        try {
+            accessToken.getInfo().put("foo", "bar");
+            org.testng.Assert.fail("Expected info map to be immutable");
+        } catch (UnsupportedOperationException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void nullNamesAreIgnored() {
+        // Given
+        ScriptableAccessToken accessToken = new ScriptableAccessToken(null);
+
+        // When
+        accessToken.setField(null, "value");
+        accessToken.removeField(null);
+
+        // Then
+        assertThat(accessToken.getFields()).isEmpty();
+        assertThat(accessToken.getRemovedFields()).isEmpty();
+    }
+}
+

--- a/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/StatelessTokenStoreTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/StatelessTokenStoreTest.java
@@ -19,8 +19,13 @@ package org.forgerock.openam.oauth2;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.JsonValue.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import com.sun.identity.shared.debug.Debug;
 import org.forgerock.json.jose.builders.JwtBuilderFactory;
@@ -79,13 +84,15 @@ public final class StatelessTokenStoreTest {
     private OAuth2Request request;
     @Mock
     private OAuth2ProviderSettings settings;
+    @Mock
+    private OAuth2AccessTokenModifier accessTokenModifier;
 
     @BeforeMethod
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         tokenStore = new StatelessTokenStore(statefulTokenStore, new JwtBuilderFactory(), providerSettingsFactory,
                 logger, clientRegistrationStore, realmNormaliser, oAuth2UrisFactory, tokenBlacklist,
-                cts, tokenAdapter, utils);
+                cts, tokenAdapter, utils, accessTokenModifier);
     }
 
     @Test
@@ -213,6 +220,61 @@ public final class StatelessTokenStoreTest {
         // Then
         assertThat(token.getTokenInfo()).doesNotContainKey("acr");
         assertThat(token.getTokenInfo()).doesNotContainKey("authModules");
+    }
+
+    @Test
+    public void whenModificationScriptReturnsClaimsTheyAreMergedIntoAccessToken() throws Exception {
+        // Given
+        givenBaseProviderSettings();
+        given(utils.getConfirmationKey(request)).willReturn(null);
+
+        Map<String, Object> modifiedClaims = new HashMap<>();
+        modifiedClaims.put("department", "engineering");
+        modifiedClaims.put("custom_number", 42);
+        given(accessTokenModifier.getModifiedClaims(any(OAuth2Request.class), anyString(), anyString(), anyString(),
+                any(), any())).willReturn(modifiedClaims);
+
+        // When
+        AccessToken token = tokenStore.createAccessToken("client_credentials", "exmple", "123-456-789", "owner-id",
+                "client-id", "http://a/b.com", singleton("open"), null, "qwerty", "some-claim", request);
+
+        // Then
+        assertThat(token.getTokenInfo().get("department")).isEqualTo("engineering");
+        assertThat(token.getTokenInfo().get("custom_number")).isEqualTo(42);
+    }
+
+    @Test
+    public void whenModificationScriptReturnsClaimsTheyAreMergedIntoRefreshToken() throws Exception {
+        // Given
+        givenBaseProviderSettings();
+
+        Map<String, Object> modifiedClaims = new HashMap<>();
+        modifiedClaims.put("department", "engineering");
+        given(accessTokenModifier.getModifiedClaims(any(OAuth2Request.class), anyString(), anyString(), anyString(),
+                any(), any())).willReturn(modifiedClaims);
+
+        // When
+        RefreshToken token = tokenStore.createRefreshToken("client_credentials", "client-id", "owner-id",
+                "http://a/b.com", singleton("open"), request, "some-claim");
+
+        // Then
+        assertThat(token.getTokenInfo().get("department")).isEqualTo("engineering");
+    }
+
+    @Test
+    public void whenModificationScriptReturnsNoClaimsTokenIsUnchanged() throws Exception {
+        // Given
+        givenBaseProviderSettings();
+        given(utils.getConfirmationKey(request)).willReturn(null);
+        given(accessTokenModifier.getModifiedClaims(any(OAuth2Request.class), anyString(), anyString(), anyString(),
+                any(), any())).willReturn(new HashMap<String, Object>());
+
+        // When
+        AccessToken token = tokenStore.createAccessToken("client_credentials", "exmple", "123-456-789", "owner-id",
+                "client-id", "http://a/b.com", singleton("open"), null, "qwerty", "some-claim", request);
+
+        // Then
+        assertThat(token.getTokenInfo()).doesNotContainKey("department");
     }
 
     private void givenBaseProviderSettings() throws Exception {

--- a/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/StatelessTokenStoreTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/StatelessTokenStoreTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2026 3A Systems LLC.
  */
 package org.forgerock.openam.oauth2;
 
@@ -19,14 +20,17 @@ import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.json.JsonValue.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import com.sun.identity.shared.debug.Debug;
 import org.forgerock.json.jose.builders.JwtBuilderFactory;
 import org.forgerock.oauth2.core.AccessToken;
+import org.forgerock.oauth2.core.AuthorizationCode;
 import org.forgerock.oauth2.core.OAuth2ProviderSettings;
 import org.forgerock.oauth2.core.OAuth2ProviderSettingsFactory;
 import org.forgerock.oauth2.core.OAuth2Request;
 import org.forgerock.oauth2.core.OAuth2Uris;
+import org.forgerock.oauth2.core.RefreshToken;
 import org.forgerock.openam.blacklist.Blacklist;
 import org.forgerock.openam.blacklist.Blacklistable;
 import org.forgerock.openam.cts.CTSPersistentStore;
@@ -127,6 +131,100 @@ public final class StatelessTokenStoreTest {
 
         // Then
         assertThat(token.getConfirmationKey().isNull()).isTrue();
+    }
+
+    @Test
+    public void whenAuthorizationCodePresentAcrAndAmrGetAddedToAccessToken() throws Exception {
+        // Given
+        givenBaseProviderSettings();
+        given(utils.getConfirmationKey(request)).willReturn(null);
+
+        AuthorizationCode authorizationCode = mock(AuthorizationCode.class);
+        given(authorizationCode.getAuthModules()).willReturn("DataStore");
+        given(authorizationCode.getAuthenticationContextClassReference()).willReturn("urn:mace:incommon:iap:silver");
+        given(authorizationCode.getSessionId()).willReturn(null);
+        given(request.getToken(AuthorizationCode.class)).willReturn(authorizationCode);
+
+        // When
+        AccessToken token = tokenStore.createAccessToken("authorization_code", "exmple", "123-456-789", "owner-id",
+                "client-id", "http://a/b.com", singleton("open"), null, "qwerty", "some-claim", request);
+
+        // Then
+        assertThat(token.getTokenInfo().get("acr")).isEqualTo("urn:mace:incommon:iap:silver");
+        assertThat(token.getTokenInfo().get("authModules")).isEqualTo("DataStore");
+    }
+
+    @Test
+    public void whenRefreshTokenPresentAcrAndAmrGetAddedToAccessToken() throws Exception {
+        // Given
+        givenBaseProviderSettings();
+        given(utils.getConfirmationKey(request)).willReturn(null);
+
+        RefreshToken currentRefreshToken = mock(RefreshToken.class);
+        given(currentRefreshToken.getAuthModules()).willReturn("LDAP");
+        given(currentRefreshToken.getAuthenticationContextClassReference()).willReturn("urn:mace:incommon:iap:bronze");
+        given(request.getToken(RefreshToken.class)).willReturn(currentRefreshToken);
+
+        // When
+        AccessToken token = tokenStore.createAccessToken("refresh_token", "exmple", "123-456-789", "owner-id",
+                "client-id", "http://a/b.com", singleton("open"), null, "qwerty", "some-claim", request);
+
+        // Then
+        assertThat(token.getTokenInfo().get("acr")).isEqualTo("urn:mace:incommon:iap:bronze");
+        assertThat(token.getTokenInfo().get("authModules")).isEqualTo("LDAP");
+    }
+
+    @Test
+    public void whenRefreshTokenPresentItOverridesAuthorizationCodeAcrAndAmr() throws Exception {
+        // Given
+        givenBaseProviderSettings();
+        given(utils.getConfirmationKey(request)).willReturn(null);
+
+        AuthorizationCode authorizationCode = mock(AuthorizationCode.class);
+        given(authorizationCode.getAuthModules()).willReturn("DataStore");
+        given(authorizationCode.getAuthenticationContextClassReference()).willReturn("acr-from-code");
+        given(authorizationCode.getSessionId()).willReturn(null);
+        given(request.getToken(AuthorizationCode.class)).willReturn(authorizationCode);
+
+        RefreshToken currentRefreshToken = mock(RefreshToken.class);
+        given(currentRefreshToken.getAuthModules()).willReturn("LDAP");
+        given(currentRefreshToken.getAuthenticationContextClassReference()).willReturn("acr-from-refresh");
+        given(request.getToken(RefreshToken.class)).willReturn(currentRefreshToken);
+
+        // When
+        AccessToken token = tokenStore.createAccessToken("refresh_token", "exmple", "123-456-789", "owner-id",
+                "client-id", "http://a/b.com", singleton("open"), null, "qwerty", "some-claim", request);
+
+        // Then
+        assertThat(token.getTokenInfo().get("acr")).isEqualTo("acr-from-refresh");
+        assertThat(token.getTokenInfo().get("authModules")).isEqualTo("LDAP");
+    }
+
+    @Test
+    public void whenNoAcrOrAmrAvailableTheyAreNotAddedToAccessToken() throws Exception {
+        // Given
+        givenBaseProviderSettings();
+        given(utils.getConfirmationKey(request)).willReturn(null);
+
+        // When
+        AccessToken token = tokenStore.createAccessToken("client_credentials", "exmple", "123-456-789", "owner-id",
+                "client-id", "http://a/b.com", singleton("open"), null, "qwerty", "some-claim", request);
+
+        // Then
+        assertThat(token.getTokenInfo()).doesNotContainKey("acr");
+        assertThat(token.getTokenInfo()).doesNotContainKey("authModules");
+    }
+
+    private void givenBaseProviderSettings() throws Exception {
+        given(providerSettingsFactory.get(request)).willReturn(settings);
+        given(clientRegistrationStore.get("client-id", request)).willReturn(null);
+        given(request.getParameter("realm")).willReturn("/abc");
+        given(realmNormaliser.normalise("/abc")).willReturn("/def");
+        given(oAuth2UrisFactory.get(request)).willReturn(oAuth2Uris);
+        given(oAuth2Uris.getIssuer()).willReturn("some-issuer");
+        given(settings.getTokenSigningAlgorithm()).willReturn("HS256");
+        given(settings.getSupportedIDTokenSigningAlgorithms()).willReturn(singleton("HS256"));
+        given(settings.getTokenHmacSharedSecret()).willReturn("c2VjcmV0");
     }
 
 }

--- a/openam-oauth2/src/test/resources/access-token-modification.groovy
+++ b/openam-oauth2/src/test/resources/access-token-modification.groovy
@@ -1,0 +1,74 @@
+/*
+* The contents of this file are subject to the terms of the Common Development and
+* Distribution License (the License). You may not use this file except in compliance with the
+* License.
+*
+* You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+* specific language governing permission and limitations under the License.
+*
+* When distributing Covered Software, include this CDDL Header Notice in each file and include
+* the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+* Header, with the fields enclosed by brackets [] replaced by your own identifying
+* information: "Portions copyright [year] [name of copyright owner]".
+*
+* Copyright 2026 3A Systems LLC.
+*/
+
+/*
+ * This is the default OAuth2 Access Token Modification script. It is executed when a stateless
+ * (JWT) OAuth2 access token or refresh token is issued, allowing additional claims to be added to,
+ * or existing claims to be modified/removed from, the token payload.
+ *
+ * Defined variables:
+ *
+ * accessToken - org.forgerock.openam.oauth2.ScriptableAccessToken
+ *               The token being issued. Use the following methods to modify it:
+ *                   accessToken.setField(String name, Object value)  - add or override a claim
+ *                   accessToken.getField(String name)                - read a claim or context value
+ *                   accessToken.removeField(String name)             - remove a custom claim
+ *               Read-only context values exposed via getField(...) include: "tokenName",
+ *               "sub", "realm", "clientId", "scope", "grantType", "acr", "amr".
+ *
+ * scopes      - java.util.Set<String>
+ *               The scopes granted to the token.
+ *
+ * identity    - com.sun.identity.idm.AMIdentity (may be null)
+ *               The identity of the resource owner, when resolvable.
+ *
+ * session     - com.iplanet.sso.SSOToken (may be null)
+ *               The user's session, present if the request carried a valid session.
+ *
+ * requestProperties - java.util.Map<String, Object>
+ *               Selected properties of the OAuth2 request, e.g. "clientId", "realm", "grantType".
+ *
+ * logger      - com.sun.identity.shared.debug.Debug
+ *               The "OAuth2Provider" debug logger instance.
+ *
+ * The script does not need to return a value: mutations applied to the accessToken object are
+ * merged into the issued token.
+ */
+
+// Example: propagate the authentication context class reference and authentication modules.
+def acr = accessToken.getField("acr")
+if (acr != null) {
+    accessToken.setField("acr", acr)
+}
+
+def amr = accessToken.getField("amr")
+if (amr != null) {
+    accessToken.setField("amr", amr)
+}
+
+// Example: expose the resource owner's email as a custom claim.
+// if (identity != null) {
+//     def mail = identity.getAttribute("mail")
+//     if (mail != null && !mail.isEmpty()) {
+//         accessToken.setField("email", mail.iterator().next())
+//     }
+// }
+
+if (logger.messageEnabled()) {
+    logger.message("OAuth2 Access Token Modification script executed for scopes: " + scopes)
+}
+
+

--- a/openam-radius/openam-radius-server/src/test/java/org/forgerock/openam/radius/server/RadiusRequestHandlerTest.java
+++ b/openam-radius/openam-radius-server/src/test/java/org/forgerock/openam/radius/server/RadiusRequestHandlerTest.java
@@ -31,7 +31,7 @@ import org.forgerock.openam.radius.server.spi.handlers.AcceptAllHandler;
 import org.forgerock.openam.radius.server.spi.handlers.RejectAllHandler;
 import org.testng.annotations.Test;
 
-import java.net.Inet4Address;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
@@ -68,8 +68,7 @@ public class RadiusRequestHandlerTest {
         // given
         final RadiusRequestContext reqCtx = mock(RadiusRequestContext.class);
         final ClientConfig clientConfig = mock(ClientConfig.class);
-        String url = "forgerock.org";
-        InetSocketAddress socketAddress = new InetSocketAddress(Inet4Address.getByName(url), 6836);
+        InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6836);
 
         when(reqCtx.getClientConfig()).thenReturn(clientConfig);
         when(reqCtx.getSource()).thenReturn(socketAddress);
@@ -104,8 +103,7 @@ public class RadiusRequestHandlerTest {
         // given
         final RadiusRequestContext reqCtx = mock(RadiusRequestContext.class);
         final ClientConfig clientConfig = mock(ClientConfig.class);
-        String url = "forgerock.org";
-        InetSocketAddress socketAddress = new InetSocketAddress(Inet4Address.getByName(url), 6836);
+        InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6836);
 
         when(reqCtx.getClientConfig()).thenReturn(clientConfig);
         when(reqCtx.getSource()).thenReturn(socketAddress);
@@ -141,8 +139,7 @@ public class RadiusRequestHandlerTest {
         // given
         final RadiusRequestContext reqCtx = mock(RadiusRequestContext.class);
         final ClientConfig clientConfig = mock(ClientConfig.class);
-        String url = "forgerock.org";
-        InetSocketAddress socketAddress = new InetSocketAddress(Inet4Address.getByName(url), 6836);
+        InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6836);
 
         when(reqCtx.getClientConfig()).thenReturn(clientConfig);
         when(reqCtx.getSource()).thenReturn(socketAddress);

--- a/openam-scripting/pom.xml
+++ b/openam-scripting/pom.xml
@@ -13,7 +13,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
- * Portions Copyrighted 2017-2025 3A Systems, LLC
+ * Portions Copyrighted 2017-2026 3A Systems, LLC
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -231,6 +231,10 @@
                                 <content>
                                     <id>oidc-claims-extension-groovy</id>
                                     <file>${project.build.sourceDirectory}/../groovy/oidc-claims-extension.groovy</file>
+                                </content>
+                                <content>
+                                    <id>access-token-modification-groovy</id>
+                                    <file>${project.build.sourceDirectory}/../groovy/access-token-modification.groovy</file>
                                 </content>
                                 <content>
                                     <id>policy-condition-js</id>

--- a/openam-scripting/src/main/groovy/access-token-modification.groovy
+++ b/openam-scripting/src/main/groovy/access-token-modification.groovy
@@ -1,0 +1,73 @@
+/*
+* The contents of this file are subject to the terms of the Common Development and
+* Distribution License (the License). You may not use this file except in compliance with the
+* License.
+*
+* You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+* specific language governing permission and limitations under the License.
+*
+* When distributing Covered Software, include this CDDL Header Notice in each file and include
+* the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+* Header, with the fields enclosed by brackets [] replaced by your own identifying
+* information: "Portions copyright [year] [name of copyright owner]".
+*
+* Copyright 2026 3A Systems LLC.
+*/
+
+/*
+ * This is the default OAuth2 Access Token Modification script. It is executed when a stateless
+ * (JWT) OAuth2 access token or refresh token is issued, allowing additional claims to be added to,
+ * or existing claims to be modified/removed from, the token payload.
+ *
+ * Defined variables:
+ *
+ * accessToken - org.forgerock.openam.oauth2.ScriptableAccessToken
+ *               The token being issued. Use the following methods to modify it:
+ *                   accessToken.setField(String name, Object value)  - add or override a claim
+ *                   accessToken.getField(String name)                - read a claim or context value
+ *                   accessToken.removeField(String name)             - remove a custom claim
+ *               Read-only context values exposed via getField(...) include: "tokenName",
+ *               "sub", "realm", "clientId", "scope", "grantType", "acr", "amr".
+ *
+ * scopes      - java.util.Set<String>
+ *               The scopes granted to the token.
+ *
+ * identity    - com.sun.identity.idm.AMIdentity (may be null)
+ *               The identity of the resource owner, when resolvable.
+ *
+ * session     - com.iplanet.sso.SSOToken (may be null)
+ *               The user's session, present if the request carried a valid session.
+ *
+ * requestProperties - java.util.Map<String, Object>
+ *               Selected properties of the OAuth2 request, e.g. "clientId", "realm", "grantType".
+ *
+ * logger      - com.sun.identity.shared.debug.Debug
+ *               The "OAuth2Provider" debug logger instance.
+ *
+ * The script does not need to return a value: mutations applied to the accessToken object are
+ * merged into the issued token.
+ */
+
+// Example: propagate the authentication context class reference and authentication modules.
+def acr = accessToken.getField("acr")
+if (acr != null) {
+    accessToken.setField("acr", acr)
+}
+
+def amr = accessToken.getField("amr")
+if (amr != null) {
+    accessToken.setField("amr", amr)
+}
+
+// Example: expose the resource owner's email as a custom claim.
+// if (identity != null) {
+//     def mail = identity.getAttribute("mail")
+//     if (mail != null && !mail.isEmpty()) {
+//         accessToken.setField("email", mail.iterator().next())
+//     }
+// }
+
+if (logger.messageEnabled()) {
+    logger.message("OAuth2 Access Token Modification script executed for scopes: " + scopes)
+}
+

--- a/openam-scripting/src/main/java/org/forgerock/openam/scripting/ScriptConstants.java
+++ b/openam-scripting/src/main/java/org/forgerock/openam/scripting/ScriptConstants.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems LLC.
  */
 package org.forgerock.openam.scripting;
 
@@ -70,6 +71,7 @@ public final class ScriptConstants {
     public static final String AUTHENTICATION_SERVER_SIDE_NAME = "AUTHENTICATION_SERVER_SIDE";
     public static final String POLICY_CONDITION_NAME = "POLICY_CONDITION";
     public static final String OIDC_CLAIMS_NAME = "OIDC_CLAIMS";
+    public static final String OAUTH2_ACCESS_TOKEN_MODIFICATION_NAME = "OAUTH2_ACCESS_TOKEN_MODIFICATION";
     public static final String SCRIPTING_HTTP_CLIENT_NAME = "ScriptingHttpClient";
 
     /**
@@ -79,7 +81,8 @@ public final class ScriptConstants {
         AUTHENTICATION_SERVER_SIDE,
         AUTHENTICATION_CLIENT_SIDE,
         POLICY_CONDITION,
-        OIDC_CLAIMS
+        OIDC_CLAIMS,
+        OAUTH2_ACCESS_TOKEN_MODIFICATION
     }
 
     /**
@@ -96,6 +99,8 @@ public final class ScriptConstants {
         DEVICE_ID_MATCH_CLIENT_SIDE("Device Id (Match) - Client Side", "157298c0-7d31-4059-a95b-eeb08473b7e5",
                 AUTHENTICATION_CLIENT_SIDE),
         OIDC_CLAIMS_SCRIPT("OIDC Claims Script", "36863ffb-40ec-48b9-94b1-9a99f71cc3b5", OIDC_CLAIMS),
+        OAUTH2_ACCESS_TOKEN_MODIFICATION_SCRIPT("OAuth2 Access Token Modification Script",
+                "d22f9a0c-426a-4466-b95e-d0f125b0d5fa", OAUTH2_ACCESS_TOKEN_MODIFICATION),
         POLICY_CONDITION_SCRIPT("Policy Condition", "9de3eb62-f131-4fac-a294-7bd170fd4acb", POLICY_CONDITION);
 
         private final String displayName;

--- a/openam-scripting/src/main/java/org/forgerock/openam/scripting/ScriptEngineConfigurator.java
+++ b/openam-scripting/src/main/java/org/forgerock/openam/scripting/ScriptEngineConfigurator.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions copyright 2025 3A Systems LLC.
+ * Portions copyright 2025-2026 3A Systems LLC.
  */
 
 package org.forgerock.openam.scripting;
@@ -87,6 +87,7 @@ public class ScriptEngineConfigurator implements ServiceListener {
                 updateConfig(POLICY_CONDITION);
                 updateConfig(AUTHENTICATION_SERVER_SIDE);
                 updateConfig(OIDC_CLAIMS);
+                updateConfig(OAUTH2_ACCESS_TOKEN_MODIFICATION);
                 initialised = true;
 
             } catch (SSOException | SMSException e) {

--- a/openam-scripting/src/main/java/org/forgerock/openam/scripting/guice/ScriptingGuiceModule.java
+++ b/openam-scripting/src/main/java/org/forgerock/openam/scripting/guice/ScriptingGuiceModule.java
@@ -12,17 +12,19 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
- * Portions copyright 2025 3A Systems LLC.
+ * Portions copyright 2025-2026 3A Systems LLC.
  */
 
 package org.forgerock.openam.scripting.guice;
 
 import static org.forgerock.openam.scripting.ScriptConstants.AUTHENTICATION_SERVER_SIDE_NAME;
 import static org.forgerock.openam.scripting.ScriptConstants.OIDC_CLAIMS_NAME;
+import static org.forgerock.openam.scripting.ScriptConstants.OAUTH2_ACCESS_TOKEN_MODIFICATION_NAME;
 import static org.forgerock.openam.scripting.ScriptConstants.POLICY_CONDITION_NAME;
 import static org.forgerock.openam.scripting.ScriptConstants.SCRIPTING_HTTP_CLIENT_NAME;
 import static org.forgerock.openam.scripting.ScriptConstants.ScriptContext.AUTHENTICATION_SERVER_SIDE;
 import static org.forgerock.openam.scripting.ScriptConstants.ScriptContext.OIDC_CLAIMS;
+import static org.forgerock.openam.scripting.ScriptConstants.ScriptContext.OAUTH2_ACCESS_TOKEN_MODIFICATION;
 import static org.forgerock.openam.scripting.ScriptConstants.ScriptContext.POLICY_CONDITION;
 
 import java.util.concurrent.BlockingQueue;
@@ -83,6 +85,10 @@ public class ScriptingGuiceModule extends AbstractModule {
 
         bind(StandardScriptEngineManager.class)
                 .annotatedWith(Names.named(OIDC_CLAIMS.name()))
+                .toInstance(new StandardScriptEngineManager());
+
+        bind(StandardScriptEngineManager.class)
+                .annotatedWith(Names.named(OAUTH2_ACCESS_TOKEN_MODIFICATION.name()))
                 .toInstance(new StandardScriptEngineManager());
 
         bind(RestletHttpClient.class)
@@ -150,6 +156,26 @@ public class ScriptingGuiceModule extends AbstractModule {
     @Named(OIDC_CLAIMS_NAME)
     ScriptEvaluator getOidcClaimsScriptEvaluator(
             @Named(OIDC_CLAIMS_NAME) StandardScriptEngineManager scriptEngineManager,
+            AMExecutorServiceFactory executorServiceFactory) {
+
+        return createEvaluator(scriptEngineManager, executorServiceFactory);
+    }
+
+    /**
+     * Creates the script evaluator to use for evaluating OAuth2 Access Token Modification scripts. The evaluator
+     * returned uses a thread pool to evaluate scripts (supporting script interruption), delegating to a sandboxed
+     * script evaluator.
+     *
+     * @param scriptEngineManager the script engine manager to use.
+     * @param executorServiceFactory the factory for creating managed thread pools for script execution.
+     * @return an appropriately configured script evaluator for use with OAuth2 Access Token Modification scripts.
+     */
+    @Provides
+    @Singleton
+    @Inject
+    @Named(OAUTH2_ACCESS_TOKEN_MODIFICATION_NAME)
+    ScriptEvaluator getOAuth2AccessTokenModificationScriptEvaluator(
+            @Named(OAUTH2_ACCESS_TOKEN_MODIFICATION_NAME) StandardScriptEngineManager scriptEngineManager,
             AMExecutorServiceFactory executorServiceFactory) {
 
         return createEvaluator(scriptEngineManager, executorServiceFactory);

--- a/openam-scripting/src/main/java/org/forgerock/openam/scripting/service/ScriptConfigurationService.java
+++ b/openam-scripting/src/main/java/org/forgerock/openam/scripting/service/ScriptConfigurationService.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems LLC.
  */
 package org.forgerock.openam.scripting.service;
 
@@ -469,6 +470,8 @@ public class ScriptConfigurationService implements ScriptingService, ServiceList
                 return serverSideAuthenticationUsageCount(script.getId());
             case OIDC_CLAIMS:
                 return oidcClaimsUsageCount(script.getId());
+            case OAUTH2_ACCESS_TOKEN_MODIFICATION:
+                return accessTokenModificationUsageCount(script.getId());
             case POLICY_CONDITION:
                 return policyConditionUsageCount(script.getId());
             default:
@@ -555,6 +558,31 @@ public class ScriptConfigurationService implements ScriptingService, ServiceList
         try {
             Set<String> sunKeyValues = getMapSetThrows(attributes, "sunKeyValue");
             if (sunKeyValues.contains("forgerock-oauth2-provider-oidc-claims-extension-script=" + uuid)) {
+                return 1;
+            }
+        } catch (ValueNotFoundException ignored) {
+        }
+
+        return 0;
+    }
+
+    /**
+     * Count how many times the script identified by the specified uuid is used as an OAuth2 Access Token
+     * Modification script.
+     *
+     * @param uuid The specified uuid.
+     * @return the count of how many times the script is used as an OAuth2 Access Token Modification script.
+     * @throws SMSException If the LDAP node could not be read.
+     * @throws SSOException If the Admin token could not be found.
+     */
+    private int accessTokenModificationUsageCount(String uuid) throws SSOException, SMSException {
+
+        SMSEntry smsEntry = new SMSEntry(getToken(), getOAuth2ProviderBaseDN());
+        Map<String, Set<String>> attributes = smsEntry.getAttributes();
+
+        try {
+            Set<String> sunKeyValues = getMapSetThrows(attributes, "sunKeyValue");
+            if (sunKeyValues.contains("forgerock-oauth2-provider-access-token-modification-script=" + uuid)) {
                 return 1;
             }
         } catch (ValueNotFoundException ignored) {

--- a/openam-scripting/src/main/resources/scripting.properties
+++ b/openam-scripting/src/main/resources/scripting.properties
@@ -11,6 +11,7 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2015 ForgeRock AS.
+# Portions Copyright 2026 3A Systems LLC.
 
 ########################################################################################################################
 # This section holds the error messages used by the Scripting framework and specifically used by ScriptException
@@ -59,6 +60,7 @@ script-type-01=Policy Condition
 script-type-02=Server-side Authentication
 script-type-03=Client-side Authentication
 script-type-04=OIDC Claims
+script-type-05=OAuth2 Access Token Modification
 
 engine-configuration=Engine Configuration
 

--- a/openam-scripting/src/main/resources/scripting.xml
+++ b/openam-scripting/src/main/resources/scripting.xml
@@ -13,6 +13,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2018-2026 3A Systems LLC.
 -->
 <!DOCTYPE ServicesConfiguration
     PUBLIC "=//iPlanet//Service Management Services (SMS) 1.0 DTD//EN" "jar://com/sun/identity/sm/sms.dtd">
@@ -22,7 +23,7 @@
 
         <Schema serviceHierarchy="/DSAMEConfig/ScriptingService"
                 i18nFileName="scripting"
-                revisionNumber="1"
+                revisionNumber="2"
                 i18nKey="service-description"
                 resourceName="scripting">
             <Global>
@@ -33,6 +34,7 @@
                         <ChoiceValue i18nKey="script-type-02">AUTHENTICATION_SERVER_SIDE</ChoiceValue>
                         <ChoiceValue i18nKey="script-type-03">AUTHENTICATION_CLIENT_SIDE</ChoiceValue>
                         <ChoiceValue i18nKey="script-type-04">OIDC_CLAIMS</ChoiceValue>
+                        <ChoiceValue i18nKey="script-type-05">OAUTH2_ACCESS_TOKEN_MODIFICATION</ChoiceValue>
                     </ChoiceValues>
                     <DefaultValues>
                         <Value>POLICY_CONDITION</Value>
@@ -224,6 +226,7 @@
                                 <ChoiceValue i18nKey="script-type-02">AUTHENTICATION_SERVER_SIDE</ChoiceValue>
                                 <ChoiceValue i18nKey="script-type-03">AUTHENTICATION_CLIENT_SIDE</ChoiceValue>
                                 <ChoiceValue i18nKey="script-type-04">OIDC_CLAIMS</ChoiceValue>
+                                <ChoiceValue i18nKey="script-type-05">OAUTH2_ACCESS_TOKEN_MODIFICATION</ChoiceValue>
                             </ChoiceValues>
                         </AttributeSchema>
                         <AttributeSchema name="createdBy" type="single" syntax="string" i18nKey="no-i18n" order="1000"/>
@@ -365,6 +368,61 @@
                         </AttributeValuePair>
                     </SubConfiguration>
                 </SubConfiguration>
+                <SubConfiguration name="OAUTH2_ACCESS_TOKEN_MODIFICATION" id="scriptContext">
+                    <AttributeValuePair>
+                        <Attribute name="i18nKey"/>
+                        <Value>script-type-05</Value>
+                    </AttributeValuePair>
+                    <AttributeValuePair>
+                        <Attribute name="defaultScript"/>
+                        <Value>@GlobalAccessTokenModificationScriptId@</Value>
+                    </AttributeValuePair>
+                    <SubConfiguration name="engineConfiguration" id="engineConfiguration">
+                        <AttributeValuePair>
+                            <Attribute name="whiteList"/>
+                            <Value>java.lang.Boolean</Value>
+                            <Value>java.lang.Byte</Value>
+                            <Value>java.lang.Character</Value>
+                            <Value>java.lang.Character$Subset</Value>
+                            <Value>java.lang.Character$UnicodeBlock</Value>
+                            <Value>java.lang.Double</Value>
+                            <Value>java.lang.Float</Value>
+                            <Value>java.lang.Integer</Value>
+                            <Value>java.lang.Long</Value>
+                            <Value>java.lang.Math</Value>
+                            <Value>java.lang.Number</Value>
+                            <Value>java.lang.Object</Value>
+                            <Value>java.lang.Short</Value>
+                            <Value>java.lang.StrictMath</Value>
+                            <Value>java.lang.String</Value>
+                            <Value>java.lang.Void</Value>
+                            <Value>java.util.ArrayList</Value>
+                            <Value>java.util.Arrays</Value>
+                            <Value>java.util.Collections</Value>
+                            <Value>java.util.HashSet</Value>
+                            <Value>java.util.HashMap</Value>
+                            <Value>java.util.HashMap$Entry</Value>
+                            <Value>java.util.HashMap$KeyIterator</Value>
+                            <Value>java.util.HashMap$Node</Value>
+                            <Value>java.util.LinkedHashMap</Value>
+                            <Value>java.util.LinkedHashMap$Entry</Value>
+                            <Value>java.util.LinkedHashMap$LinkedEntrySet</Value>
+                            <Value>java.util.LinkedHashMap$LinkedKeyIterator</Value>
+                            <Value>java.util.LinkedHashSet</Value>
+                            <Value>java.util.LinkedList</Value>
+                            <Value>java.util.TreeMap</Value>
+                            <Value>java.util.TreeSet</Value>
+                            <Value>com.sun.identity.shared.debug.Debug</Value>
+                            <Value>com.iplanet.sso.providers.dpro.SSOTokenImpl</Value>
+                            <Value>org.forgerock.http.client.*</Value>
+                            <Value>groovy.json.JsonSlurper</Value>
+                            <Value>com.sun.identity.idm.AMIdentity</Value>
+                            <Value>org.forgerock.openam.oauth2.ScriptableAccessToken</Value>
+                            <Value>org.codehaus.groovy.runtime.GStringImpl</Value>
+                            <Value>org.forgerock.openam.sso.providers.stateless.StatelessSSOToken</Value>
+                        </AttributeValuePair>
+                    </SubConfiguration>
+                </SubConfiguration>
                 <SubConfiguration name="globalScripts" id="globalScripts">
                     <SubConfiguration name="@GlobalEntitlementConditionScriptId@" id="globalScript">
                         <AttributeValuePair>
@@ -488,6 +546,30 @@
                             <Attribute name="script"/>
                             <Value>
                                 ${inject.content.oidc-claims-extension-groovy}
+                            </Value>
+                        </AttributeValuePair>
+                    </SubConfiguration>
+                    <SubConfiguration name="@GlobalAccessTokenModificationScriptId@" id="globalScript">
+                        <AttributeValuePair>
+                            <Attribute name="name"/>
+                            <Value>OAuth2 Access Token Modification Script</Value>
+                        </AttributeValuePair>
+                        <AttributeValuePair>
+                            <Attribute name="description"/>
+                            <Value>Default global script for OAuth2 Access Token Modification</Value>
+                        </AttributeValuePair>
+                        <AttributeValuePair>
+                            <Attribute name="context"/>
+                            <Value>OAUTH2_ACCESS_TOKEN_MODIFICATION</Value>
+                        </AttributeValuePair>
+                        <AttributeValuePair>
+                            <Attribute name="language"/>
+                            <Value>GROOVY</Value>
+                        </AttributeValuePair>
+                        <AttributeValuePair>
+                            <Attribute name="script"/>
+                            <Value>
+                                ${inject.content.access-token-modification-groovy}
                             </Value>
                         </AttributeValuePair>
                     </SubConfiguration>

--- a/openam-server-only/src/main/resources/config/serviceDefaultValues.properties
+++ b/openam-server-only/src/main/resources/config/serviceDefaultValues.properties
@@ -26,6 +26,7 @@
 #
 
 # Portions Copyrighted 2011-2016 ForgeRock AS.
+# Portions Copyright 2018-2026 3A Systems LLC.
 
 XML_ENCODING=ISO-8859-1
 LOG_DIR=log
@@ -102,4 +103,5 @@ GlobalClientSideAuthModuleScriptId=c827d2b4-3608-4693-868e-bbcf86bd87c7
 GlobalServerSideDeviceIdMatchScriptId=703dab1a-1921-4981-98dd-b8e5349d8548
 GlobalClientSideDeviceIdMatchScriptId=157298c0-7d31-4059-a95b-eeb08473b7e5
 GlobalOidcClaimsScriptId=36863ffb-40ec-48b9-94b1-9a99f71cc3b5
+GlobalAccessTokenModificationScriptId=d22f9a0c-426a-4466-b95e-d0f125b0d5fa
 NoScriptDefined=[Empty]

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/helpers/OAuth2ProviderUpgradeHelper.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/helpers/OAuth2ProviderUpgradeHelper.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems LLC.
  */
 
 package org.forgerock.openam.upgrade.helpers;
@@ -38,6 +39,7 @@ public class OAuth2ProviderUpgradeHelper extends AbstractUpgradeHelper {
         attributes.add(JKWS_URI);
         attributes.add(SUPPORTED_CLAIMS);
         attributes.add(OIDC_CLAIMS_EXTENSION_SCRIPT);
+        attributes.add(ACCESS_TOKEN_MODIFICATION_SCRIPT);
         attributes.add(SCOPE_PLUGIN_CLASS);
 
         attributes.add(AUTHZ_CODE_LIFETIME_NAME);
@@ -64,6 +66,7 @@ public class OAuth2ProviderUpgradeHelper extends AbstractUpgradeHelper {
             case ID_TOKEN_SIGNING_ALGORITHMS:
             case SUPPORTED_CLAIMS:
             case OIDC_CLAIMS_EXTENSION_SCRIPT:
+            case ACCESS_TOKEN_MODIFICATION_SCRIPT:
             case RESPONSE_TYPE_LIST:
             case SCOPE_PLUGIN_CLASS:
             case AUTHZ_CODE_LIFETIME_NAME:


### PR DESCRIPTION
## Summary

This PR introduces a fully-fledged **OAuth2 Access Token Modification script type**
(script context `OAUTH2_ACCESS_TOKEN_MODIFICATION`), analogous to ForgeRock AM 6.5.

It adds a supported extension point that allows **custom claims** (e.g. `acr`,
`amr`, roles, profile attributes) to be embedded **directly into stateless (JWT)
OAuth 2.0 access tokens and refresh tokens** at issue time — without an extra
call to `/oauth2/tokeninfo`.

Closes / addresses: **OpenAM Discussion [#1027](https://github.com/OpenIdentityPlatform/OpenAM/discussions/1027)**

## Background / Problem

The stateless JWT claim set is built in
[`StatelessTokenStore.createAccessToken(...)`](openam-oauth2/src/main/java/org/forgerock/openam/oauth2/StatelessTokenStore.java)
directly through `JwtClaimsSetBuilder` with a **hard-coded set of fields and no
extension point**.

As a result, by design:

- The **OIDC Claims Script**, custom **Scope Implementation Class**, and
  scope-to-claim mappings are **never invoked** when issuing a stateless JWT
  access token (they only apply to `id_token`, `/userinfo`, `/tokeninfo`).
- Unlike commercial ForgeRock AM 6.5+, OpenIdentityPlatform/OpenAM had **no
  Access Token Modification Script**.

Users therefore could not get `acr`/`amr`/custom claims into the access token
payload without an additional `/tokeninfo` round-trip.

## Solution

A new script context `OAUTH2_ACCESS_TOKEN_MODIFICATION` is executed when a
stateless access token **or** refresh token is issued. Claims the script adds,
modifies, or removes are merged into the token payload before signing.

The script runs in **both** `createAccessToken` and `createRefreshToken`, so
custom claims survive the refresh cycle.

### Script bindings

| Binding             | Type                     | Description                                                                       |
|---------------------|--------------------------|-----------------------------------------------------------------------------------|
| `accessToken`       | `ScriptableAccessToken`  | Mutable view of the token: `setField` / `getField` / `removeField`                |
| `scopes`            | `Set<String>`            | Granted scopes                                                                    |
| `identity`          | `AMIdentity` (nullable)  | Resource owner identity                                                           |
| `session`           | `SSOToken` (nullable)    | User session if present                                                           |
| `requestProperties` | `Map<String, Object>`    | Selected request properties (`clientId`, `realm`, `grantType`)                    |
| `logger`            | `Debug`                  | `OAuth2Provider` debug logger                                                     |

### Default script (Groovy)

A safe default global script is shipped (UUID
`d22f9a0c-426a-4466-b95e-d0f125b0d5fa`). It propagates `acr`/`amr` and includes
commented examples (e.g. adding `email`). When the provider setting is
`[Empty]`, the token is issued unchanged.

## Changes

### Scripting infrastructure (`openam-scripting`)
- `ScriptConstants`: new `ScriptContext.OAUTH2_ACCESS_TOKEN_MODIFICATION`,
  `*_NAME` constant, `GlobalScript` entry.
- `ScriptingGuiceModule`: `StandardScriptEngineManager` + named `ScriptEvaluator`.
- `ScriptEngineConfigurator`: register engine config for the new context.
- `ScriptConfigurationService`: usage-count handling for the new context.
- `scripting.xml` / `scripting.properties`: choice values, context sub-config
  with class whitelist, default global Groovy script.
- `groovy/access-token-modification.groovy`: default script + `pom.xml` inject.

### OAuth2 (`openam-oauth2` / `openam-core`)
- `OAuth2Constants`: provider setting
  `forgerock-oauth2-provider-access-token-modification-script`, new
  `ScriptParams` (`accessToken`, `requestProperties`).
- `ScriptableAccessToken` *(new)*: mutable token view exposed to scripts.
- `OAuth2AccessTokenModifier` *(new)*: loads & evaluates the script, builds
  bindings, returns claims to merge.
- `StatelessTokenStore`: invokes the modifier and merges claims in both
  `createAccessToken` and `createRefreshToken`.
- `OAuth2GuiceModule`: threads the new dependency into the realm-agnostic store.
- `OAuth2Provider.xml` / `.properties` / `.section.properties`: new provider
  attribute with `scriptSelect` UI type.

### Upgrade / defaults
- `OAuth2ProviderUpgradeHelper`: registers the new attribute for upgrades.
- `serviceDefaultValues.properties`: `GlobalAccessTokenModificationScriptId`.

### Documentation (`openam-documentation`)
- Dev Guide: `chap-scripting.adoc` (new API section + context list),
  `chap-client-dev.adoc` (language table + context values).
- Reference: `chap-config-ref.adoc` (provider attribute + scripting context).
- Admin Guide: `chap-manage-scripts.adoc` (context enum).

### Tests
- `StatelessTokenStoreTest`: +4 tests (claims merged into access token & refresh
  token; empty result leaves token unchanged; constructor update).
- `ScriptableAccessTokenTest` *(new)*: 6 tests for the binding object API.

## UI impact

**None required.** Script contexts and the OAuth2 Provider attribute are rendered
dynamically from the service schema (`ScriptsService.getAllContexts()` /
`getContextSchema()`, and the `scriptSelect` attribute via `ScriptChoiceValues`).
`OIDC_CLAIMS` is likewise never hard-coded in the UI.

## Backwards compatibility

Fully backwards compatible. When no script is selected (`[Empty]`), the token is
issued exactly as before. The feature only applies to stateless (JWT) tokens.

## How to use

1. Realms → *Realm* → Services → **OAuth2 Provider** → Core.
2. Enable **Use Stateless Access & Refresh Tokens**.
3. Set **OAuth2 Access Token Modification Script** (default:
   `OAuth2 Access Token Modification Script`), or edit the global script under
   Realms → *Realm* → Scripts.

## Testing

```bash
mvn -o -pl openam-oauth2 test -Dtest=StatelessTokenStoreTest,ScriptableAccessTokenTest
# Tests run: 15, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

Affected modules also compile cleanly:

```bash
mvn -o -pl openam-core,openam-scripting,openam-oauth2,openam-upgrade -am compile -DskipTests
```
