### PR TITLE
CVE-2026-45536 CVE-2026-45416 CVE-2026-44249 Netty: Unix-socket fd receive leaks descriptors when peer sends two at once Netty: SNI handler pre-allocates up to 16 MiB from nine attacker bytes Netty has an IPv6 Subnet Filter Bypass via Incorrect Comparator Masking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@
     <license.version>1.0.0</license.version>
     <checkstyleFailOnError>false</checkstyleFailOnError>
     <logback.version>1.3.15</logback.version>
-    <netty.version>4.2.13.Final</netty.version>
     <netty-tcnative-boringssl.version>2.0.69.Final</netty-tcnative-boringssl.version>
     <javadoc.opts>-Xdoclint:none</javadoc.opts>
     <java.surefire.options>
@@ -1727,94 +1726,6 @@
             <artifactId>jnr-posix</artifactId>
             <version>3.1.11</version>
         </dependency>
-        <dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-parent</artifactId>
-			<version>${netty.version}</version>
-			<type>pom</type>
-		</dependency>
-        <dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-all</artifactId>
-			<version>${netty.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-common</artifactId>
-			<version>${netty.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-resolver</artifactId>
-			<version>${netty.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-transport</artifactId>
-			<version>${netty.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-handler</artifactId>
-			<version>${netty.version}</version>
-		</dependency>
-		<dependency>
-  			<groupId>io.netty</groupId>
-  			<artifactId>netty-transport-native-epoll</artifactId>
-  			<version>${netty.version}</version>
-  		</dependency>
-  		<dependency>
-  			<groupId>io.netty</groupId>
-  			<artifactId>netty-transport-native-epoll</artifactId>
-  			<version>${netty.version}</version>
-  			<classifier>linux-x86_64</classifier>
-  		</dependency>
-  		<dependency>
-  			<groupId>io.netty</groupId>
-  			<artifactId>netty-transport-native-kqueue</artifactId>
-  			<version>${netty.version}</version>
-  		</dependency>
-  		<dependency>
-  			<groupId>io.netty</groupId>
-  			<artifactId>netty-transport-native-kqueue</artifactId>
-  			<version>${netty.version}</version>
-  			<classifier>osx-x86_64</classifier>
-  		</dependency>
-  		<dependency>
-  			<groupId>io.netty</groupId>
-  			<artifactId>netty-transport-native-unix-common</artifactId>
-  			<version>${netty.version}</version>
-  		</dependency>
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-buffer</artifactId>
-			<version>${netty.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-codec-http</artifactId>
-			<version>${netty.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-codec-socks</artifactId>
-			<version>${netty.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-handler-proxy</artifactId>
-			<version>${netty.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-transport-classes-epoll</artifactId>
-			<version>${netty.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-transport-classes-kqueue</artifactId>
-			<version>${netty.version}</version>
-		</dependency>
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-tcnative-boringssl-static</artifactId>


### PR DESCRIPTION
replace
* https://github.com/OpenIdentityPlatform/OpenAM/pull/1038
* https://github.com/OpenIdentityPlatform/OpenAM/pull/1039
* https://github.com/OpenIdentityPlatform/OpenAM/pull/1040
