### PR TITLE
Create base entry on external configuration store during setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,13 +32,12 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run:  | 
         echo "MAVEN_PROFILE_FLAG=-P integration-test" >> $GITHUB_OUTPUT 
-        echo "MAVEN_VERIFY_STAGE=verify" >> $GITHUB_OUTPUT
         echo "127.0.0.1 openam.local" | sudo tee -a /etc/hosts
       id: maven-profile-flag
     - name: Build with Maven
       env:
         MAVEN_OPTS: -Dhttps.protocols=TLSv1.2 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.http.retryHandler.count=10
-      run: mvn --batch-mode --errors --update-snapshots package ${{ steps.maven-profile-flag.outputs.MAVEN_VERIFY_STAGE }} --file pom.xml ${{ steps.maven-profile-flag.outputs.MAVEN_PROFILE_FLAG }}
+      run: mvn --batch-mode --errors --update-snapshots verify --file pom.xml ${{ steps.maven-profile-flag.outputs.MAVEN_PROFILE_FLAG }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v6
       with:

--- a/openam-core/src/main/java/com/sun/identity/config/wizard/Step3.java
+++ b/openam-core/src/main/java/com/sun/identity/config/wizard/Step3.java
@@ -26,6 +26,7 @@
  *
  * Portions Copyrighted 2010-2016 ForgeRock AS.
  * Portions Copyright 2016 Nomura Research Institute, Ltd.
+ * Portions Copyright 2025-2026 3A Systems, LLC
  */
 
 package com.sun.identity.config.wizard;
@@ -48,6 +49,7 @@ import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.DN;
 import org.forgerock.opendj.ldap.EntryNotFoundException;
 import org.forgerock.opendj.ldap.LdapException;
+import org.forgerock.opendj.ldap.ResultCode;
 
 /**
  * Step 3 is for selecting the embedded or external configuration store 
@@ -623,19 +625,31 @@ public class Step3 extends LDAPStoreWizardPage {
         }
 
         /*
-         * Check if the provided root suffix exists and 'services' entry does not exist under the suffix in the existing
-         * SM host. If not, OpenAM denies setting up.
+         * Make sure the chosen config store does not already contain an OpenAM configuration (a 'services' entry under
+         * the root suffix). The root suffix itself does not need to exist yet: if it is missing OpenAM will create the
+         * base entry during installation. Only a real connection/authentication failure prevents proceeding.
          */
         try (Connection conn = getConnection(host, port, bindDN, bindPwd.toCharArray(), 5, ssl)) {
-            conn.readEntry(DN.valueOf(rootSuffix));
+            boolean servicesExist;
             try {
                 conn.readEntry(DN.valueOf(rootSuffix).child("ou", "services"));
-                writeToResponse(getLocalizedString("config.data.already.exist"));
+                servicesExist = true;
             } catch (EntryNotFoundException enfe) {
+                // Either the suffix or the 'services' entry is missing - safe to set up.
+                servicesExist = false;
+            }
+            if (servicesExist) {
+                writeToResponse(getLocalizedString("config.data.already.exist"));
+            } else {
                 writeToResponse("ok");
             }
         } catch (LdapException lex) {
-            if (!writeErrorToResponse(lex.getResult().getResultCode())) {
+            ResultCode resultCode = lex.getResult().getResultCode();
+            if (ResultCode.NO_SUCH_OBJECT.equals(resultCode)) {
+                // The root suffix (or its parent) does not exist yet - OpenAM will create the base entry during
+                // installation, so this is allowed.
+                writeToResponse("ok");
+            } else if (!writeErrorToResponse(resultCode)) {
                 writeToResponse(getLocalizedString("cannot.connect.to.SM.datastore"));
             }
         } catch (Exception e) {

--- a/openam-core/src/main/java/com/sun/identity/setup/AMSetupDSConfig.java
+++ b/openam-core/src/main/java/com/sun/identity/setup/AMSetupDSConfig.java
@@ -25,7 +25,7 @@
  * $Id: AMSetupDSConfig.java,v 1.20 2009/11/20 23:52:55 ww203982 Exp $
  *
  * Portions Copyrighted 2011-2016 ForgeRock AS.
- * Portions Copyrighted 2025 3A Systems LLC.
+ * Portions Copyrighted 2022-2026 3A Systems LLC.
  */
 package com.sun.identity.setup;
 
@@ -53,8 +53,10 @@ import org.forgerock.opendj.ldap.DN;
 import org.forgerock.opendj.ldap.Filter;
 import org.forgerock.opendj.ldap.LDAPConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
+import org.forgerock.opendj.ldap.ResultCode;
 import org.forgerock.opendj.ldap.SSLContextBuilder;
 import org.forgerock.opendj.ldap.SearchScope;
+import org.forgerock.opendj.ldap.requests.AddRequest;
 import org.forgerock.opendj.ldap.requests.SimpleBindRequest;
 import org.forgerock.opendj.ldif.ConnectionEntryReader;
 import org.forgerock.util.Options;
@@ -212,6 +214,85 @@ public class AMSetupDSConfig {
         } catch (LdapException e) {
             disconnectDServer();
             return false;
+        }
+    }
+
+    /**
+     * Ensures that the base entry (root suffix) exists in an external directory
+     * server, creating it when it is missing.
+     *
+     * <p>For an embedded OpenDJ the suffix is created from
+     * <code>openam_suffix.ldif</code>. When OpenAM is installed against an
+     * external directory server the suffix is assumed to already exist (e.g.
+     * created by the OpenDJ docker image with <code>--addBaseEntry</code>).
+     * This method makes OpenAM create the base entry itself so the installation
+     * succeeds even when the suffix has not been pre-created.</p>
+     *
+     * <p>The method is idempotent: if the suffix already exists nothing is
+     * done. The object class of the created entry is derived from the naming
+     * attribute of the suffix (<code>dc</code>, <code>o</code> or
+     * <code>ou</code>).</p>
+     *
+     * @param ssl <code>true</code> if the directory server is running on LDAPS.
+     * @throws ConfiguratorException if the base entry cannot be created.
+     */
+    public void createBaseEntry(boolean ssl) throws ConfiguratorException {
+        if ((suffix == null) || (suffix.trim().length() == 0)) {
+            return;
+        }
+        // Suffix already present - nothing to do.
+        if (connectDSwithDN(ssl)) {
+            return;
+        }
+
+        DN suffixDN = DN.valueOf(suffix);
+        String namingAttr = suffixDN.rdn().getFirstAVA().getAttributeType().getNameOrOID();
+        String rdnValue = LDAPUtils.rdnValueFromDn(suffixDN);
+
+        SetupProgress.reportStart("emb.creatingfamsuffix", null);
+        Connection conn = getLDAPConnection(ssl);
+        if (conn == null) {
+            SetupProgress.reportEnd("emb.creatingfamsuffix.failure", new Object[] { suffix });
+            Debug.getInstance(SetupConstants.DEBUG_NAME).error(
+                    "AMSetupDSConfig.createBaseEntry: unable to connect to directory server");
+            throw new ConfiguratorException("configurator.dsconnnectfailure", null, locale);
+        }
+        try {
+            AddRequest addRequest = LDAPRequests.newAddRequest(suffixDN)
+                    .addAttribute("objectClass", "top");
+
+            if ("dc".equalsIgnoreCase(namingAttr)) {
+                addRequest.addAttribute("objectClass", "domain")
+                        .addAttribute("dc", rdnValue);
+            } else if ("o".equalsIgnoreCase(namingAttr)) {
+                addRequest.addAttribute("objectClass", "organization")
+                        .addAttribute("o", rdnValue);
+            } else if ("ou".equalsIgnoreCase(namingAttr)) {
+                addRequest.addAttribute("objectClass", "organizationalUnit")
+                        .addAttribute("ou", rdnValue);
+            } else {
+                // Fallback for any other naming attribute.
+                addRequest.addAttribute("objectClass", "extensibleObject")
+                        .addAttribute(namingAttr, rdnValue);
+            }
+
+            conn.add(addRequest);
+            SetupProgress.reportEnd("emb.creatingfamsuffix.success", null);
+        } catch (LdapException e) {
+            // Created concurrently or already present - acceptable.
+            if (e.getResult() != null && ResultCode.ENTRY_ALREADY_EXISTS.equals(e.getResult().getResultCode())) {
+                SetupProgress.reportEnd("emb.creatingfamsuffix.success", null);
+                return;
+            }
+            Object[] error = { suffix };
+            SetupProgress.reportEnd("emb.creatingfamsuffix.failure", error);
+            Debug.getInstance(SetupConstants.DEBUG_NAME).error(
+                    "AMSetupDSConfig.createBaseEntry: failed to create base entry " + suffix, e);
+            InstallLog.getInstance().write(
+                    "AMSetupDSConfig.createBaseEntry: failed to create base entry " + suffix, e);
+            throw new ConfiguratorException("configurator.ldiferror", null, locale);
+        } finally {
+            conn.close();
         }
     }
 

--- a/openam-core/src/main/java/com/sun/identity/setup/AMSetupServlet.java
+++ b/openam-core/src/main/java/com/sun/identity/setup/AMSetupServlet.java
@@ -25,7 +25,7 @@
  * $Id: AMSetupServlet.java,v 1.117 2010/01/20 17:01:35 veiming Exp $
  *
  * Portions Copyrighted 2010-2016 ForgeRock AS.
- * Portions Copyrighted 2017-2025 3A Systems, LLC.
+ * Portions Copyrighted 2017-2026 3A Systems, LLC.
  */
 
 package com.sun.identity.setup;
@@ -1474,6 +1474,18 @@ public class AMSetupServlet extends HttpServlet {
         SetupProgress.reportEnd("emb.success", null);
         
         AMSetupDSConfig dsConfig = AMSetupDSConfig.getInstance();
+
+        // For an external configuration store the root suffix (base entry) is
+        // assumed to already exist. Create it if it is missing so OpenAM can be
+        // installed against an external OpenDJ without pre-creating the base DN
+        // (e.g. without the OpenDJ "--addBaseEntry" option). The embedded store
+        // creates the suffix separately via openam_suffix.ldif.
+        if (SetupConstants.SMS_DS_DATASTORE.equals(dataStore)) {
+            String sslEnabled = (String) map.get(SetupConstants.CONFIG_VAR_DIRECTORY_SERVER_SSL);
+            boolean ssl = "SSL".equals(sslEnabled);
+            dsConfig.createBaseEntry(ssl);
+        }
+
         dsConfig.loadSchemaFiles(schemaFiles);
 
         if (dataStore.equals(SetupConstants.SMS_EMBED_DATASTORE)) {

--- a/openam-core/src/main/java/com/sun/identity/setup/ServicesDefaultValues.java
+++ b/openam-core/src/main/java/com/sun/identity/setup/ServicesDefaultValues.java
@@ -25,6 +25,7 @@
  * $Id: ServicesDefaultValues.java,v 1.38 2009/01/28 05:35:02 ww203982 Exp $
  *
  * Portions Copyrighted 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2022-2026 3A Systems LLC.
  */
 
 package com.sun.identity.setup;
@@ -155,12 +156,24 @@ public class ServicesDefaultValues {
                 throw new ConfiguratorException(
                     "configurator.dsconnnectfailure", null, locale);
             }
-            if ((!LDAPUtils.isDN((String) map.get(
-                    SetupConstants.CONFIG_VAR_ROOT_SUFFIX))) ||
-                (!dsConfig.connectDSwithDN(ssl))) {
+            if (!LDAPUtils.isDN((String) map.get(
+                    SetupConstants.CONFIG_VAR_ROOT_SUFFIX))) {
                 dsConfig = null;
                 throw new ConfiguratorException("configurator.invalidsuffix",
                     null, locale);
+            }
+            if (!dsConfig.connectDSwithDN(ssl)) {
+                // The base DN (root suffix) does not exist yet on the external
+                // directory server. Create it (mirrors the embedded behaviour
+                // that loads openam_suffix.ldif) so OpenAM can be installed
+                // without pre-creating the base entry (e.g. without the OpenDJ
+                // "--addBaseEntry" option).
+                dsConfig.createBaseEntry(ssl);
+                if (!dsConfig.connectDSwithDN(ssl)) {
+                    dsConfig = null;
+                    throw new ConfiguratorException("configurator.invalidsuffix",
+                        null, locale);
+                }
             }
 
             map.put(SetupConstants.DIT_LOADED, dsConfig.isDITLoaded(ssl));

--- a/openam-core/src/main/java/com/sun/identity/setup/UserIdRepo.java
+++ b/openam-core/src/main/java/com/sun/identity/setup/UserIdRepo.java
@@ -25,7 +25,7 @@
  * $Id: UserIdRepo.java,v 1.21 2009/12/23 00:22:34 goodearth Exp $
  *
  * Portions Copyrighted 2011-2016 ForgeRock AS.
- * Portions Copyrighted 2025 3A Systems LLC.
+ * Portions Copyrighted 2024-2026 3A Systems LLC.
  */
 
 package com.sun.identity.setup;
@@ -74,10 +74,13 @@ import org.forgerock.openam.ldap.LdifUtils;
 import org.forgerock.opendj.ldap.Attribute;
 import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.ConnectionFactory;
+import org.forgerock.opendj.ldap.DN;
 import org.forgerock.opendj.ldap.LDAPConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
+import org.forgerock.opendj.ldap.ResultCode;
 import org.forgerock.opendj.ldap.SearchScope;
 import org.forgerock.opendj.ldap.SSLContextBuilder;
+import org.forgerock.opendj.ldap.requests.AddRequest;
 import org.forgerock.opendj.ldap.requests.SimpleBindRequest;
 import org.forgerock.opendj.ldap.responses.SearchResultEntry;
 import org.forgerock.opendj.ldif.ConnectionEntryReader;
@@ -276,6 +279,14 @@ class UserIdRepo {
         String type
     ) throws Exception {
         try (Connection conn = getLDAPConnection(userRepo)){
+            // The user store schema/initialisation LDIFs (e.g. opendj_userinit.ldif)
+            // add entries such as "ou=people,<root suffix>" under the user store
+            // root suffix. The root suffix (base entry) itself is assumed to
+            // already exist. Create it if it is missing so OpenAM can be configured
+            // against an external directory whose base DN has not been pre-created
+            // (e.g. without the OpenDJ "--addBaseEntry" option).
+            createBaseEntry(conn, (String) userRepo.get(
+                SetupConstants.USER_STORE_ROOT_SUFFIX));
             String dbName = getDBName(userRepo, conn);
             for (String file :  writeSchemaFiles(basedir, dbName, servletCtx, strFiles, userRepo, type)) {
                 Object[] params = {file};
@@ -287,7 +298,72 @@ class UserIdRepo {
             }
         }
     }
-    
+
+    /**
+     * Creates the user store root suffix (base entry) when it does not already
+     * exist. The object class of the created entry is derived from the naming
+     * attribute of the suffix (<code>dc</code>, <code>o</code> or
+     * <code>ou</code>). If the base entry is already present this is a no-op.
+     *
+     * @param conn   an open connection to the user store directory server.
+     * @param suffix the user store root suffix DN.
+     * @throws LdapException if the base entry cannot be created.
+     */
+    private void createBaseEntry(Connection conn, String suffix) throws LdapException {
+        if ((suffix == null) || (suffix.trim().length() == 0)) {
+            return;
+        }
+        DN suffixDN = DN.valueOf(suffix);
+
+        // Base entry already present - nothing to do.
+        try {
+            ConnectionEntryReader reader = conn.search(LDAPRequests.newSearchRequest(
+                suffix, SearchScope.BASE_OBJECT, "(objectclass=*)"));
+            if (reader.hasNext()) {
+                return;
+            }
+        } catch (LdapException e) {
+            if ((e.getResult() == null)
+                    || !ResultCode.NO_SUCH_OBJECT.equals(e.getResult().getResultCode())) {
+                throw e;
+            }
+            // NO_SUCH_OBJECT - the base entry is missing, fall through to create it.
+        }
+
+        String namingAttr = suffixDN.rdn().getFirstAVA().getAttributeType().getNameOrOID();
+        String rdnValue = LDAPUtils.rdnValueFromDn(suffixDN);
+
+        Object[] params = {suffix};
+        SetupProgress.reportStart("emb.creatingfamsuffix", params);
+
+        AddRequest addRequest = LDAPRequests.newAddRequest(suffixDN)
+                .addAttribute("objectClass", "top");
+        if ("dc".equalsIgnoreCase(namingAttr)) {
+            addRequest.addAttribute("objectClass", "domain").addAttribute("dc", rdnValue);
+        } else if ("o".equalsIgnoreCase(namingAttr)) {
+            addRequest.addAttribute("objectClass", "organization").addAttribute("o", rdnValue);
+        } else if ("ou".equalsIgnoreCase(namingAttr)) {
+            addRequest.addAttribute("objectClass", "organizationalUnit").addAttribute("ou", rdnValue);
+        } else {
+            // Fallback for any other naming attribute.
+            addRequest.addAttribute("objectClass", "extensibleObject").addAttribute(namingAttr, rdnValue);
+        }
+
+        try {
+            conn.add(addRequest);
+            SetupProgress.reportEnd("emb.success", null);
+        } catch (LdapException e) {
+            // Created concurrently or already present - acceptable.
+            if ((e.getResult() != null)
+                    && ResultCode.ENTRY_ALREADY_EXISTS.equals(e.getResult().getResultCode())) {
+                SetupProgress.reportEnd("emb.success", null);
+                return;
+            }
+            SetupProgress.reportEnd("emb.failed", null);
+            throw e;
+        }
+    }
+
     private List<String> writeSchemaFiles(
         String basedir, 
         String dbName,

--- a/openam-server/pom.xml
+++ b/openam-server/pom.xml
@@ -126,12 +126,19 @@
                             </properties>
                             <pingURL>http://localhost:8207/am</pingURL>
                         </deployable>
+                        <deployable>
+                            <type>war</type>
+                            <properties>
+                                <context>am2</context>
+                            </properties>
+                            <pingURL>http://localhost:8207/am2</pingURL>
+                        </deployable>
 	                </deployables>
 	                <configuration>
 				    	<properties>
 				        	<cargo.rmi.port>8206</cargo.rmi.port>
 				        	<cargo.servlet.port>8207</cargo.servlet.port>
-    			        	<cargo.jvmargs>${java.surefire.options} </cargo.jvmargs>
+    			        	<cargo.jvmargs>${java.surefire.options} -Xmx2g</cargo.jvmargs>
 				        </properties>
 				    </configuration>
                 </configuration>

--- a/openam-server/pom.xml
+++ b/openam-server/pom.xml
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>2.0.4</version>
+            <version>2.0.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/openam-server/pom.xml
+++ b/openam-server/pom.xml
@@ -166,7 +166,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.43.0</version>
+            <version>4.44.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/openam-server/src/test/java/org/openidentityplatform/openam/test/integration/IT_SetupWithOpenDJ.java
+++ b/openam-server/src/test/java/org/openidentityplatform/openam/test/integration/IT_SetupWithOpenDJ.java
@@ -38,23 +38,38 @@ public class IT_SetupWithOpenDJ extends BaseTest {
 
     @Test
     public void testSetupWithOpendj() throws Exception {
+        // External OpenDJ WITHOUT a pre-created base DN - OpenAM must create the base entry itself.
+        runSetup("http://openam.local:8207/am", false);
+    }
 
-        final String openamUrl = "http://openam.local:8207/am";
+    @Test
+    public void testSetupWithOpendjAddBaseEntry() throws Exception {
+        // External OpenDJ WITH a pre-created base DN (OpenDJ "--addBaseEntry").
+        // Uses a separate webapp context (/am2) because an OpenAM instance can only be configured once.
+        runSetup("http://openam.local:8207/am2", true);
+    }
+
+    private void runSetup(String openamUrl, boolean addBaseEntry) throws Exception {
 
         if(!DockerClientFactory.instance().isDockerAvailable()) {
             throw new SkipException("docker is not available");
         }
 
-        try(GenericContainer<?> opendj =
+        GenericContainer<?> opendj =
                     new GenericContainer<>(DockerImageName.parse("openidentityplatform/opendj:latest"))
                             .withExposedPorts(1389, 4444)
-                            .waitingFor(Wait.forHealthcheck().withStartupTimeout(Duration.ofMinutes(5)))) {
+                            .waitingFor(Wait.forHealthcheck().withStartupTimeout(Duration.ofMinutes(10)));
+        if (addBaseEntry) {
+            opendj.withEnv("ADD_BASE_ENTRY", "--addBaseEntry");
+        }
 
-            opendj.start();
+        try (GenericContainer<?> opendjContainer = opendj) {
+
+            opendjContainer.start();
 
             System.out.println("containers started");
 
-            Integer opendjPort = opendj.getMappedPort(1389);
+            Integer opendjPort = opendjContainer.getMappedPort(1389);
 
             testOpenAmInstallation(openamUrl, opendjPort);
 
@@ -130,7 +145,7 @@ public class IT_SetupWithOpenDJ extends BaseTest {
 
         wait.until(ExpectedConditions.elementToBeClickable(By.id("writeConfigButton"))).click();
 
-        WebDriverWait waitComplete = new WebDriverWait(driver, Duration.ofSeconds(300));
+        WebDriverWait waitComplete = new WebDriverWait(driver, Duration.ofSeconds(600));
         try {
             WebElement proceedToConsole = waitComplete.until(visibilityOfAnyElement(By.cssSelector("#confComplete a")));
             proceedToConsole.click();


### PR DESCRIPTION
## Summary

OpenAM could not be installed against an **external OpenDJ** when the base DN
(root suffix, e.g. `dc=openam,dc=example,dc=org`) had not been created in advance.
Installation only succeeded when the directory was started with the OpenDJ
`--addBaseEntry` option (the `ADD_BASE_ENTRY` environment variable in the
OpenDJ Docker image).

This PR makes OpenAM create the base entry itself when it is missing, mirroring
the behaviour of the embedded configuration store (which creates the suffix via
`openam_suffix.ldif`). The `--addBaseEntry` / `ADD_BASE_ENTRY` workaround is no
longer required.

## Problem

During setup against an external store:

- `AMSetupServlet.setupSMDatastore()` only loaded schema/indexes (`dsSmsSchema`)
  but never created the root suffix.
- The setup wizard validation (`Step3.validateSMHost()`) reported an error when
  the suffix was absent, leaving the **Next** button disabled.
- The install-time validation (`ServicesDefaultValues.setServiceConfigValues()`)
  failed with `configurator.invalidsuffix` when the suffix did not exist.

As a result the only way to proceed was to pre-create the base DN on the
directory server.

## Changes

### Product code (`openam-core`)

- **`AMSetupDSConfig`** — added `createBaseEntry(boolean ssl)`:
  - returns early when the suffix already exists (existence check),
  - derives the `objectClass` from the RDN naming attribute
    (`dc` → `domain`, `o` → `organization`, `ou` → `organizationalUnit`,
    otherwise `extensibleObject`),
  - is idempotent — handles `ENTRY_ALREADY_EXISTS`,
  - reports progress via `SetupProgress` and logs/raises `ConfiguratorException`
    on real failures.
- **`AMSetupServlet.writeSchemaFiles()`** — calls `createBaseEntry()` before
  loading schema files for an external (`SMS_DS_DATASTORE`) configuration store.
- **`ServicesDefaultValues.setServiceConfigValues()`** — creates the base entry
  instead of failing with `configurator.invalidsuffix` when the suffix is
  missing; only fails if creation does not result in a reachable suffix.
- **`Step3.validateSMHost()`** (setup wizard) — treats a missing root suffix
  (`NO_SUCH_OBJECT` / `EntryNotFoundException`) as valid so the **Next** button
  is enabled; only real connection/authentication errors block progress.

### Tests (`openam-server`)

- **`IT_SetupWithOpenDJ`** — integration tests covering both scenarios against a
  Testcontainers OpenDJ:
  - `testSetupWithOpendj` — external OpenDJ **without** a pre-created base DN
    (OpenAM creates the base entry),
  - `testSetupWithOpendjAddBaseEntry` — external OpenDJ **with** a pre-created
    base DN (`ADD_BASE_ENTRY=--addBaseEntry`).
- **`pom.xml`** — added a separate `/am2` webapp context (an OpenAM instance can
  only be configured once per webapp), raised the Tomcat heap to `-Xmx2g`, and
  extended container startup / install timeouts.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| External OpenDJ, base DN pre-created (`--addBaseEntry`) | ✅ works | ✅ works |
| External OpenDJ, base DN **not** created | ❌ fails | ✅ OpenAM creates the base entry |
| Embedded OpenDJ | ✅ works (unchanged) | ✅ works (unchanged) |

## Backward compatibility

No behavioural change for existing deployments where the base DN already exists
or `--addBaseEntry` is used — `createBaseEntry()` is a no-op in those cases.

## Testing

- `IT_SetupWithOpenDJ` — both new tests pass (with and without `ADD_BASE_ENTRY`).
- Full integration suite: `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0` —
  **BUILD SUCCESS**.
