### PR TITLE
Add openam-samples modules to the main reactor

### DIFF
--- a/openam-mcp-server/pom.xml
+++ b/openam-mcp-server/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.openidentityplatform.openam</groupId>
 		<artifactId>openam</artifactId>
-		<version>16.0.7-SNAPSHOT</version>
+		<version>16.1.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>openam-mcp-server</artifactId>
 	<name>OpenAM MCP Server</name>

--- a/openam-samples/custom-authentication-module/pom.xml
+++ b/openam-samples/custom-authentication-module/pom.xml
@@ -13,6 +13,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions copyright 2026 3A Systems, LLC
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -21,7 +22,8 @@
     <parent>
         <groupId>org.openidentityplatform.openam</groupId>
         <artifactId>openam</artifactId>
-        <version>14.6.7-SNAPSHOT</version>
+        <version>16.1.2-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.openidentityplatform.openam.examples</groupId>
     <artifactId>custom-authentication-module</artifactId>

--- a/openam-samples/policy-evaluation-plugin/pom.xml
+++ b/openam-samples/policy-evaluation-plugin/pom.xml
@@ -13,6 +13,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions copyright 2026 3A Systems, LLC
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -22,7 +23,8 @@
     <parent>
         <groupId>org.openidentityplatform.openam</groupId>
         <artifactId>openam</artifactId>
-        <version>14.6.7-SNAPSHOT</version>
+        <version>16.1.2-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.openidentityplatform.openam.examples</groupId>
     <artifactId>policy-evaluation-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,9 @@
     <!-- openam cassandra submodules -->
     <module>openam-cassandra</module>
     <module>transform-jakarta</module>
+    <!-- OpenAM Samples / Examples -->
+    <module>openam-samples/custom-authentication-module</module>
+    <module>openam-samples/policy-evaluation-plugin</module>
   </modules>
   <!-- Mailing Lists -->
   <mailingLists>


### PR DESCRIPTION
Register custom-authentication-module and policy-evaluation-plugin as
modules in the root pom so the samples are built with the main reactor.
Bump their stale parent version from 14.6.7-SNAPSHOT to 16.1.2-SNAPSHOT
and set parent relativePath to the root pom so they resolve both in the
reactor and when built standalone.
