### PR TITLE
Add revocation_endpoint to OpenID Connect discovery document

### DIFF
--- a/openam-mcp-server/pom.xml
+++ b/openam-mcp-server/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.openidentityplatform.openam</groupId>
 		<artifactId>openam</artifactId>
-		<version>16.0.7-SNAPSHOT</version>
+		<version>16.1.1</version>
 	</parent>
 	<artifactId>openam-mcp-server</artifactId>
 	<name>OpenAM MCP Server</name>

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2Uris.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2Uris.java
@@ -113,4 +113,11 @@ public interface OAuth2Uris {
      * @return The URL.
      */
     String getDeviceAuthorizationEndpoint();
+    
+    /**
+     * Returns the default URL for this provider's token Revocation endpoint.
+     *
+     * @return The URL.
+     */
+    String getRevocationEndpoint();
 }

--- a/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/OAuth2UrisFactory.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/OAuth2UrisFactory.java
@@ -203,5 +203,10 @@ public class OAuth2UrisFactory {
         public String getDeviceAuthorizationEndpoint() {
             return baseUrl + "/device/code";
         }
+        
+        @Override
+        public String getRevocationEndpoint() {
+            return baseUrl + "/revoke";
+        }
     }
 }

--- a/openam-oauth2/src/main/java/org/forgerock/openidconnect/OpenIDConnectProviderConfiguration.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openidconnect/OpenIDConnectProviderConfiguration.java
@@ -102,6 +102,7 @@ public class OpenIDConnectProviderConfiguration {
         configuration.put("claims_parameter_supported", providerSettings.getClaimsParameterSupported());
         configuration.put("token_endpoint_auth_methods_supported", providerSettings.getEndpointAuthMethodsSupported());
         configuration.put("device_authorization_endpoint", uris.getDeviceAuthorizationEndpoint());
+        configuration.put("revocation_endpoint", uris.getRevocationEndpoint());
 
         return new JsonValue(configuration);
     }


### PR DESCRIPTION
Summary

This pull request adds the revocation_endpoint metadata to the OpenID Connect Discovery document (/.well-known/openid-configuration).

The token revocation endpoint is already implemented by OpenAM (/oauth2/revoke), but it is not advertised in the OpenID Connect discovery document.

Changes
Added getRevocationEndpoint() to OAuth2Uris.
Implemented the endpoint in OAuth2UrisFactory.OAuth2UrisImpl.
Added the revocation_endpoint property to OpenIDConnectProviderConfiguration.

Example

Before:

{
  "token_endpoint": "https://server/oauth2/access_token"
}

After:

{
  "token_endpoint": "https://server/oauth2/access_token",
  "revocation_endpoint": "https://server/oauth2/revoke"
}
Compatibility

This change is fully backward compatible, as it only adds an additional metadata field to the discovery document and does not modify any existing endpoint behavior.
This endpoint is defined by RFC 7009 and can be advertised through the authorization server metadata used by OpenID Connect Discovery.