### PR TITLE
Add CodeQL code scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -93,7 +93,6 @@ jobs:
               - '**/node_modules/**'
               - '**/test-output/**'
               - 'openam-ui/openam-ui-ria/src/main/js/libs/**'
-              - 'openam-ui/openam-ui-js-sdk/src/lib/**'
               # .NET build output (generated AssemblyInfo, compiled artifacts).
               - '**/obj/**'
               - '**/bin/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,122 @@
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2026 3A Systems, LLC.
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ 'master' ]
+  pull_request:
+    branches: [ 'master' ]
+  schedule:
+    # Weekly run, Mondays at 03:27 UTC
+    - cron: '27 3 * * 1'
+  # Allows running this workflow manually from the Actions tab or via the gh CLI.
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref to avoid the long-running,
+# eventually-cancelled analyses seen with the previous default setup.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      # Required to upload results to code scanning.
+      security-events: write
+      # Only needed for workflows in private repositories.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # This large multi-module Maven build is expensive to compile, so we
+          # use build-mode 'none': CodeQL builds its model straight from the
+          # Java/Kotlin sources without invoking Maven. This avoids the long,
+          # eventually-cancelled autobuild that the previous default setup hit.
+          #
+          # For higher precision (dataflow through compiled dependencies) switch
+          # this to 'manual' and uncomment the "Build with Maven" step below.
+          - language: java-kotlin
+            build-mode: none
+          # Interpreted languages: no compilation, extracted straight from source.
+          - language: javascript-typescript
+            build-mode: none
+          # The Fedlet .NET/SAML2 library (openam-federation-library). C#
+          # supports build-mode 'none', so it is extracted from source without
+          # needing MSBuild/nuget on the runner.
+          - language: csharp
+            build-mode: none
+          # Scans the repository's own GitHub Actions workflows.
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+          # Exclude test and integration-test sources. With build-mode 'none'
+          # CodeQL extracts straight from source, so paths-ignore reliably
+          # scopes the analysis (it is honored for compiled languages only when
+          # build-mode is 'none').
+          config: |
+            paths-ignore:
+              - '**/src/test/**'
+              - '**/src/it/**'
+              # Third-party / vendored JavaScript — analysing it only adds noise.
+              - '**/*.min.js'
+              - '**/node_modules/**'
+              - '**/test-output/**'
+              - 'openam-ui/openam-ui-ria/src/main/js/libs/**'
+              - 'openam-ui/openam-ui-js-sdk/src/lib/**'
+              # .NET build output (generated AssemblyInfo, compiled artifacts).
+              - '**/obj/**'
+              - '**/bin/**'
+
+      # --- Manual build (only used when build-mode is 'manual') -------------
+      # - name: Set up JDK 11
+      #   uses: actions/setup-java@v5
+      #   with:
+      #     java-version: '11'
+      #     distribution: 'zulu'
+      # - name: Cache Maven packages
+      #   uses: actions/cache@v6
+      #   with:
+      #     path: ~/.m2/repository
+      #     key: ${{ runner.os }}-m2-repository-${{ hashFiles('**/pom.xml') }}
+      #     restore-keys: ${{ runner.os }}-m2-repository
+      # - name: Build with Maven
+      #   env:
+      #     MAVEN_OPTS: -Dhttps.protocols=TLSv1.2 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.http.retryHandler.count=10
+      #   run: mvn --batch-mode --errors -DskipTests -Dmaven.test.skip=true clean compile --file pom.xml
+      # ---------------------------------------------------------------------
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds `.github/workflows/codeql.yml` — GitHub CodeQL code scanning for the repository.

### What it does
- **Languages** (all `build-mode: none`, i.e. source extraction — no Maven/MSBuild on the runner):
  - `java-kotlin` — primary codebase
  - `javascript-typescript` — XUI / JS sources
  - `csharp` — the Fedlet .NET SAML2 library (`openam-federation-library`)
  - `actions` — the repo's own GitHub Actions workflows
- **Triggers:** push/PR to `master`, a weekly schedule (Mon 03:27 UTC), and manual `workflow_dispatch`.
- **Query suite:** `security-and-quality`.
- **Concurrency:** cancels superseded runs on the same ref.
- **Least-privilege permissions**; pinned `checkout@v7` / `codeql-action@v4`.

### Scoping (`paths-ignore`)
Excludes tests (`src/test`, `src/it`), vendored/minified JS (`*.min.js`, `node_modules`, `test-output`, the XUI `libs` and JS-SDK `lib` trees) and .NET build output (`obj`, `bin`).

### Notes
- Python was intentionally left out — the only `.py` files are node-gyp tooling under `node_modules`.
- C/C++ was left out — it's legacy Solaris-only native glue that requires a compiled build (CodeQL C/C++ doesn't support `build-mode: none`) and won't build on `ubuntu-latest`. A commented-out manual Maven build block is included for switching Java to higher-precision `build-mode: manual` later.
