### PR TITLE
Reduce CI build matrix on macOS and Windows to min/max JDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ 'ubuntu-latest' ]
         java: [ '11', '17', '21', '25', '26' ]
-        os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
+        include:
+          - { os: 'macos-latest',   java: '11' }
+          - { os: 'macos-latest',   java: '26' }
+          - { os: 'windows-latest', java: '11' }
+          - { os: 'windows-latest', java: '26' }
       fail-fast: false
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

The `build-maven` job matrix was a full cross-product of 5 JDKs × 3 OSes = **15 jobs**. This reduces it to **9 jobs** by only exercising the minimum and maximum supported JDKs (11 and 26) on macOS and Windows.

- **ubuntu-latest** — full Java matrix `11, 17, 21, 25, 26` (also runs the integration-test profile and feeds the Docker jobs)
- **macos-latest** — `11` and `26` only (via `include`)
- **windows-latest** — `11` and `26` only (via `include`)

Because the `include` entries use `os` values that don't match the base `os: [ ubuntu-latest ]`, GitHub Actions creates them as **new** combinations rather than expanding existing ones, so JDK 17/21/25 no longer run on macOS/Windows.

## Rationale

macOS and Windows runners are the slowest and scarcest in CI; the intermediate JDKs on those platforms rarely surface OS-specific issues that the JDK edges don't. Full coverage is retained on Linux.