### PR TITLE
Add concurrency groups to CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ on:
   push:
     branches: [ 'sustaining/15.2.x','master','issues/**','features/**' ]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build-maven:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
     branches: [ 'sustaining/15.2.x','master' ]
     workflows: ["Build","Release"]
     types: [completed]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   deploy-maven:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event=='push'}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
     workflows: ["Build","Release"]
     types: [completed]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 jobs:
   deploy-maven:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
         description: "Default version to use for new local working copy."
         required: true
         default: "X.Y.Z-SNAPSHOT"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   release-maven:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
## Summary

Add a top-level `concurrency` group (keyed on `${{ github.workflow }}-${{ github.ref }}`) to the GitHub Actions workflows so redundant runs on the same ref collapse instead of piling up.

| Workflow | `cancel-in-progress` | Behaviour |
|----------|:---:|-----------|
| `build.yml` | `true` | A new push/PR build cancels the now-superseded in-flight run — the main runner-time saver. |
| `deploy.yml` | `false` | Overlapping runs **queue** rather than aborting an in-flight Maven Central publish. |
| `release.yml` | `false` | Never interrupts a release mid-way (`release:prepare`/`release:perform`, tag push, GitHub release). |

## Rationale

`cancel-in-progress: true` is safe and desirable for `build.yml`: superseded commits don't need their builds finished. For `release.yml` and `deploy.yml` it is deliberately `false` — cancelling those midway could leave a half-published Maven Central staging repo, a partial GitHub release, or dangling tags, so overlapping runs serialize instead.

## Notes

- `codeql.yml` is intentionally not touched here; it lives in a separate open PR (#1063) and is not yet on `master`.
- Independent of the build-matrix change in #1064 — different region of `build.yml`, no conflict expected.
