### PR TITLE
Run OpenFM unit tests and fix NotCondition.equals reflexivity

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/entitlement/LogicalCondition.java
+++ b/openam-core/src/main/java/com/sun/identity/entitlement/LogicalCondition.java
@@ -26,6 +26,7 @@
  */
 /*
  * Portions Copyrighted 2014-2015 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package com.sun.identity.entitlement;
 
@@ -228,25 +229,33 @@ public abstract class LogicalCondition extends EntitlementConditionAdaptor {
             return false;
         }
         LogicalCondition object = (LogicalCondition) obj;
-        if (eConditions == null) {
-            if (object.getEConditions() != null) {
+        // Read both sides through the accessors: subclasses may keep the nested
+        // conditions elsewhere and override the getters (NotCondition holds a single
+        // condition and leaves these fields null), so reading this.field against
+        // object.getter() would compare two different representations.
+        Set<EntitlementCondition> thisEConditions = getEConditions();
+        Set<EntitlementCondition> otherEConditions = object.getEConditions();
+        if (thisEConditions == null) {
+            if (otherEConditions != null) {
                 return false;
             }
         } else { // eConditions not null
-            if ((object.getEConditions()) == null) {
+            if (otherEConditions == null) {
                 return false;
-            } else if (!eConditions.containsAll(object.getEConditions())) {
+            } else if (!thisEConditions.containsAll(otherEConditions)) {
                 return false;
-            } else if (!object.getEConditions().containsAll(eConditions)) {
+            } else if (!otherEConditions.containsAll(thisEConditions)) {
                 return false;
             }
         }
-        if (pConditionName == null) {
-            if (object.getPConditionName() != null) {
+        String thisPConditionName = getPConditionName();
+        String otherPConditionName = object.getPConditionName();
+        if (thisPConditionName == null) {
+            if (otherPConditionName != null) {
                 return false;
             }
         } else {
-            if (!pConditionName.equals(object.getPConditionName())) {
+            if (!thisPConditionName.equals(otherPConditionName)) {
                 return false;
             }
         }

--- a/openam-federation/OpenFM/pom.xml
+++ b/openam-federation/OpenFM/pom.xml
@@ -30,9 +30,6 @@
     <description>OpenAM Federation</description>
     <artifactId>OpenFM</artifactId>
     <packaging>jar</packaging>
-    <properties>
-        <skipTests>true</skipTests>
-    </properties>
     <profiles>
         <profile>
             <id>set-compiler-release</id>
@@ -59,6 +56,71 @@
     </profiles>
     <!-- Build -->
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!--
+                        The excluded classes are OpenSSO-era tests that ran inside a deployed OpenAM:
+                        they obtain an Application SSO token via AdminTokenAction and drive
+                        ServiceManager/IdRepo directly. Outside a configured server they fail in the
+                        constructor or in @BeforeClass, and TestNG aborts the entire suite when one
+                        test class cannot be instantiated. That is why this module carried a blanket
+                        skipTests property from 2013 until 2026, hiding every test it owns.
+
+                        Excluding them by name keeps the remaining unit tests running, and any newly
+                        added test is still picked up by surefire's default patterns. Reviving the
+                        list below needs a live OpenAM.
+                    -->
+                    <excludes>
+                        <!-- whole packages: every test here drives a live server -->
+                        <exclude>com/sun/identity/policy/*.java</exclude>
+                        <exclude>com/sun/identity/rest/*.java</exclude>
+                        <exclude>com/sun/identity/xacml/**/*.java</exclude>
+                        <!-- in-container harness leftovers, not tests themselves -->
+                        <exclude>com/sun/identity/unittest/TestHarness.java</exclude>
+                        <exclude>com/sun/identity/unittest/TestListener.java</exclude>
+                        <!-- entitlement: unit tests share these packages, so list per class -->
+                        <exclude>com/sun/identity/entitlement/AndConditionEvalTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/ApplicationCacheAfterRealmChangeTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/ApplicationCreatorNDateTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/ApplicationDelegationTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/ApplicationFilterTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/ApplicationPrivilegeMetaTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/ApplicationTypeTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/CanBeDeletedAppTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/DecisionMergeTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/DelegationIsAllowedSubResourceTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/DelegationPrivilegeIdRepoAccessTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/DelegationPrivilegeSubResourceTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/DelegationPrivilegeTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/HttpStarEvaluationTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/IdentityGroupToEntitlementGroupTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/IDPPTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/log/LogTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/MultiWildcardEvalTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/opensso/EntitlementServiceTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/opensso/RealmRemovedTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/OrConditionEvalTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/OrgAliasReferralTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/PrivilegeDelegationTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/PrivilegeManagerTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/ReferralPrivilegeRemovalTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/ReferralPrivilegeTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/ReferralPrivilegeWithRemovedRealmTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/ReferredResourcesTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/SingleWildCardEvaluatorTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/SubRealmEvaluationTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/SubRealmGroupTest.java</exclude>
+                        <exclude>com/sun/identity/entitlement/TestAttributeEvaluator.java</exclude>
+                        <exclude>com/sun/identity/entitlement/TestEvaluator.java</exclude>
+                        <exclude>com/sun/identity/entitlement/TestGroupEvaluator.java</exclude>
+                        <exclude>com/sun/identity/entitlement/XACMLExportTest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>

--- a/openam-federation/OpenFM/src/test/java/com/sun/identity/entitlement/PrivilegeNameValidationTest.java
+++ b/openam-federation/OpenFM/src/test/java/com/sun/identity/entitlement/PrivilegeNameValidationTest.java
@@ -24,6 +24,9 @@
  *
  * $Id: PriivlegeNameValidation.java,v 1.1 2009/11/25 18:09:50 veiming Exp $
  */
+/*
+ * Portions Copyrighted 2026 3A Systems, LLC
+ */
 
 package com.sun.identity.entitlement;
 
@@ -33,13 +36,13 @@ import org.testng.annotations.Test;
  *
  * @author dennis
  */
-public class PriivlegeNameValidation {
+public class PrivilegeNameValidationTest {
 
     @Test
     public void allLetters() throws Exception {
         if (!PrivilegeManager.isNameValid("test")) {
             throw new Exception(
-                "PriivlegeNameValidation.allLetters test failed");
+                "PrivilegeNameValidationTest.allLetters test failed");
         }
     }
 
@@ -47,7 +50,7 @@ public class PriivlegeNameValidation {
     public void allNumeric() throws Exception {
         if (!PrivilegeManager.isNameValid("999")) {
             throw new Exception(
-                "PriivlegeNameValidation.allNumeric test failed");
+                "PrivilegeNameValidationTest.allNumeric test failed");
         }
     }
 
@@ -55,7 +58,7 @@ public class PriivlegeNameValidation {
     public void allAlphaNumeric() throws Exception {
         if (!PrivilegeManager.isNameValid("test123")) {
             throw new Exception(
-                "PriivlegeNameValidation.allAlphaNumeric test failed");
+                "PrivilegeNameValidationTest.allAlphaNumeric test failed");
         }
     }
 
@@ -63,7 +66,7 @@ public class PriivlegeNameValidation {
     public void withUnderscore() throws Exception {
         if (!PrivilegeManager.isNameValid("test_123")) {
             throw new Exception(
-                "PriivlegeNameValidation.withUnderscore test failed");
+                "PrivilegeNameValidationTest.withUnderscore test failed");
         }
     }
 
@@ -71,7 +74,7 @@ public class PriivlegeNameValidation {
     public void withDash() throws Exception {
         if (!PrivilegeManager.isNameValid("test-12")) {
             throw new Exception(
-                "PriivlegeNameValidation.withDash test failed");
+                "PrivilegeNameValidationTest.withDash test failed");
         }
     }
 
@@ -79,7 +82,7 @@ public class PriivlegeNameValidation {
     public void withSpecialChar() throws Exception {
         if (PrivilegeManager.isNameValid("test^")) {
             throw new Exception(
-                "PriivlegeNameValidation.withDash test failed");
+                "PrivilegeNameValidationTest.withSpecialChar test failed");
         }
     }
 

--- a/openam-federation/OpenFM/src/test/java/com/sun/identity/entitlement/util/ResourceNameSplitTest.java
+++ b/openam-federation/OpenFM/src/test/java/com/sun/identity/entitlement/util/ResourceNameSplitTest.java
@@ -44,7 +44,7 @@ import org.testng.annotations.Test;
  */
 public class ResourceNameSplitTest {
     @Test
-    public boolean testHost() 
+    public void testHost()
         throws Exception {
         ResourceNameSplitter splitter = new ResourceNameSplitter();
         Map<String, Set<String>> map = parseResource("resourceNameSplitHost");
@@ -53,35 +53,31 @@ public class ResourceNameSplitTest {
             ResourceSearchIndexes comp = splitter.getIndexes(k, null);
             Set<String> results = comp.getHostIndexes();
             if (!results.equals(set)) {
-                String msg = "ResourceNameSplitTest.testHost: " + k + 
+                String msg = "ResourceNameSplitTest.testHost: " + k +
                     " failed.";
                 UnittestLog.logError(msg);
                 throw new Exception(msg);
             }
         }
-        
-        return true;
     }
 
     @Test
-    public boolean testPath() 
+    public void testPath()
         throws Exception {
         ResourceNameSplitter splitter = new ResourceNameSplitter();
         Map<String, Set<String>> map = parseResource("resourceNameSplitURI");
         for (String k : map.keySet()) {
             Set<String> set = map.get(k);
-            
+
             ResourceSearchIndexes comp = splitter.getIndexes(k, null);
             Set<String> results = comp.getPathIndexes();
             if (!results.equals(set)) {
-                String msg = "ResourceNameSplitTest.testPath: " + k + 
+                String msg = "ResourceNameSplitTest.testPath: " + k +
                     " failed.";
                 UnittestLog.logError(msg);
                 throw new Exception(msg);
             }
         }
-        
-        return true;
     }
     
     private Map<String, Set<String>> parseResource(String rbName) {

--- a/openam-federation/OpenFM/src/test/java/com/sun/identity/workflow/ConfigureSocialAuthNTest.java
+++ b/openam-federation/OpenFM/src/test/java/com/sun/identity/workflow/ConfigureSocialAuthNTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.sun.identity.workflow;
@@ -164,7 +165,9 @@ public class ConfigureSocialAuthNTest {
         assertEquals(getMapAttr(attrs, AUTH_MODULE_CLIENT_ID), "fred");
         assertEquals(getMapAttr(attrs, AUTH_MODULE_CLIENT_SECRET), "freddy");
         assertEquals(getMapAttr(attrs, AUTH_MODULE_CRYPTO_TYPE), "client_secret");
-        assertEquals(getMapAttr(attrs, AUTH_MODULE_CRYPTO_VALUE), "freddy");
+        // OPENAM-5851: under the client_secret crypto type the validation config value is
+        // ignored in favour of the client secret itself, so the wizard leaves it unset.
+        assertNull(getMapAttr(attrs, AUTH_MODULE_CRYPTO_VALUE));
         assertEquals(getMapAttr(attrs, AUTH_MODULE_PROXY_URL), "http://example.com");
     }
 
@@ -184,7 +187,7 @@ public class ConfigureSocialAuthNTest {
         assertEquals(getMapAttr(attrs, AUTH_MODULE_CLIENT_ID), "fred");
         assertEquals(getMapAttr(attrs, AUTH_MODULE_CLIENT_SECRET), "freddy");
         assertEquals(getMapAttr(attrs, AUTH_MODULE_CRYPTO_TYPE), "client_secret");
-        assertEquals(getMapAttr(attrs, AUTH_MODULE_CRYPTO_VALUE), "freddy");
+        assertNull(getMapAttr(attrs, AUTH_MODULE_CRYPTO_VALUE));
         assertEquals(getMapAttr(attrs, AUTH_MODULE_PROXY_URL), "http://example.com");
         assertEquals(getMapAttr(attrs, AUTH_MODULE_AUTH_URL), "http://local.example.com/auth");
         assertEquals(getMapAttr(attrs, AUTH_MODULE_TOKEN_URL), "http://local.example.com/token");
@@ -211,7 +214,7 @@ public class ConfigureSocialAuthNTest {
 
         // Then
         assertEquals(getMapAttr(attrs, AUTH_MODULE_CRYPTO_TYPE), "client_secret");
-        assertEquals(getMapAttr(attrs, AUTH_MODULE_CRYPTO_VALUE), "freddy");
+        assertNull(getMapAttr(attrs, AUTH_MODULE_CRYPTO_VALUE));
     }
 
     @Test

--- a/openam-federation/OpenFM/src/test/java/com/sun/identity/workflow/CreateSoapSTSDeploymentTest.java
+++ b/openam-federation/OpenFM/src/test/java/com/sun/identity/workflow/CreateSoapSTSDeploymentTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package com.sun.identity.workflow;
@@ -45,16 +46,14 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-/*
-To actually run this test, comment-out the <skipTests>true</skipTests> property in the pom.xml and run
-mvn -Dtest=CreateSoapSTSDeploymentTest verify
-from the command-line (other tests in the test-suite don't run successfully - hence the skipTests property.)
- */
 public class CreateSoapSTSDeploymentTest {
     private static final String REALM_PARAM = "realm";
     private static final String OPENAM_URL_PARAM = "openAMUrl";
     private static final String SOAP_AGENT_NAME_PARAM = "soapAgentName";
     private static final String SOAP_AGENT_PASSWORD_PARAM = "soapAgentPassword";
+    private static final String SOAP_AGENT_RETRY_NUMBER_PARAM = "soapAgentRetryNumber";
+    private static final String SOAP_AGENT_RETRY_INITIAL_INTERVAL_PARAM = "soapAgentRetryInitialInterval";
+    private static final String SOAP_AGENT_RETRY_MULTIPLIER_PARAM = "soapAgentRetryMultiplier";
     private static final String KEYSTORE_FILE_NAMES_PARAM = "keystoreFileNames";
     private static final String WSDL_FILE_NAMES_PARAM = "wsdlFileNames";
 
@@ -62,6 +61,9 @@ public class CreateSoapSTSDeploymentTest {
     private static final String OPENAM_URL_PARAM_VALUE = "https://host.com:443/om";
     private static final String SOAP_AGENT_NAME_PARAM_VALUE = "da_soap_agent";
     private static final String SOAP_AGENT_PASSWORD_PARAM_VALUE = "da_soap_agent_pw";
+    private static final String SOAP_AGENT_RETRY_NUMBER_PARAM_VALUE = "3";
+    private static final String SOAP_AGENT_RETRY_INITIAL_INTERVAL_PARAM_VALUE = "500";
+    private static final String SOAP_AGENT_RETRY_MULTIPLIER_PARAM_VALUE = "1.5";
     private static final String KEYSTORE_FILE_NAMES_PARAM_VALUE = "keystore.jks";
     private static final String WSDL_FILE_NAMES_PARAM_VALUE = "custom.wsdl";
 
@@ -69,6 +71,10 @@ public class CreateSoapSTSDeploymentTest {
     private static final String SOAP_PROPERTY_FILE_AM_SESSION_COOKIE_NAME_KEY = "am_session_cookie_name";
     private static final String SOAP_PROPERTY_FILE_SOAP_STS_AGENT_USERNAME_KEY = "soap_sts_agent_username";
     private static final String SOAP_PROPERTY_FILE_REALM_KEY = "am_realm";
+    private static final String SOAP_PROPERTY_FILE_SOAP_STS_AGENT_RETRY_NUMBER_KEY = "soap_sts_agent_retry_number";
+    private static final String SOAP_PROPERTY_FILE_SOAP_STS_AGENT_RETRY_INITIAL_INTERVAL_KEY =
+            "soap_sts_agent_retry_initial_interval";
+    private static final String SOAP_PROPERTY_FILE_SOAP_STS_AGENT_RETRY_MULTIPLIER_KEY = "soap_sts_agent_retry_multiplier";
 
     private static final String AM_SESSION_COOKIE_NAME = "custom_cookie_name";
 
@@ -194,6 +200,12 @@ public class CreateSoapSTSDeploymentTest {
             assertEquals(warProperties.getProperty(SOAP_PROPERTY_FILE_AM_SESSION_COOKIE_NAME_KEY), AM_SESSION_COOKIE_NAME);
             assertEquals(warProperties.getProperty(SOAP_PROPERTY_FILE_SOAP_STS_AGENT_USERNAME_KEY), SOAP_AGENT_NAME_PARAM_VALUE);
             assertEquals(warProperties.getProperty(SOAP_PROPERTY_FILE_REALM_KEY), REALM_PARAM_VALUE);
+            assertEquals(warProperties.getProperty(SOAP_PROPERTY_FILE_SOAP_STS_AGENT_RETRY_NUMBER_KEY),
+                    SOAP_AGENT_RETRY_NUMBER_PARAM_VALUE);
+            assertEquals(warProperties.getProperty(SOAP_PROPERTY_FILE_SOAP_STS_AGENT_RETRY_INITIAL_INTERVAL_KEY),
+                    SOAP_AGENT_RETRY_INITIAL_INTERVAL_PARAM_VALUE);
+            assertEquals(warProperties.getProperty(SOAP_PROPERTY_FILE_SOAP_STS_AGENT_RETRY_MULTIPLIER_KEY),
+                    SOAP_AGENT_RETRY_MULTIPLIER_PARAM_VALUE);
         }
     }
 
@@ -205,6 +217,9 @@ public class CreateSoapSTSDeploymentTest {
         paramMap.put(OPENAM_URL_PARAM, OPENAM_URL_PARAM_VALUE);
         paramMap.put(SOAP_AGENT_NAME_PARAM, SOAP_AGENT_NAME_PARAM_VALUE);
         paramMap.put(SOAP_AGENT_PASSWORD_PARAM, SOAP_AGENT_PASSWORD_PARAM_VALUE);
+        paramMap.put(SOAP_AGENT_RETRY_NUMBER_PARAM, SOAP_AGENT_RETRY_NUMBER_PARAM_VALUE);
+        paramMap.put(SOAP_AGENT_RETRY_INITIAL_INTERVAL_PARAM, SOAP_AGENT_RETRY_INITIAL_INTERVAL_PARAM_VALUE);
+        paramMap.put(SOAP_AGENT_RETRY_MULTIPLIER_PARAM, SOAP_AGENT_RETRY_MULTIPLIER_PARAM_VALUE);
         if (withKeystoreFile) {
             paramMap.put(KEYSTORE_FILE_NAMES_PARAM, KEYSTORE_FILE_NAMES_PARAM_VALUE);
         }

--- a/openam-federation/OpenFM/src/test/java/com/sun/identity/workflow/CreateSoapSTSDeploymentTest.java
+++ b/openam-federation/OpenFM/src/test/java/com/sun/identity/workflow/CreateSoapSTSDeploymentTest.java
@@ -26,7 +26,6 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -85,16 +84,18 @@ public class CreateSoapSTSDeploymentTest {
 
     private static final boolean WITH_KEYSTORE_FILE = true;
     private static final boolean WITH_CUSTOM_WSDL = true;
+    /*
+    Classpath resource names, not filesystem paths: they must keep '/' on every platform, so they
+    cannot be built with Paths.get() (which yields '\' separators on Windows and resolves to null).
+     */
+    private static final String INPUT_WAR_RESOURCE = "/com/sun/identity/workflow/slim-openam-soap-sts-server.war";
+    private static final String CUSTOM_WSDL_RESOURCE = "/com/sun/identity/workflow/custom.wsdl";
+    private static final String KEYSTORE_RESOURCE = "/com/sun/identity/workflow/keystore.jks";
+
     private File outputWarFile;
-    private Path inputWarFilePath;
-    private Path customWsdlFilePath;
-    private Path keystoreFilePath;
 
     @BeforeClass
     public void setup() throws Exception {
-        inputWarFilePath = Paths.get("/com", "sun", "identity", "workflow", "slim-openam-soap-sts-server.war");
-        customWsdlFilePath = Paths.get("/com", "sun", "identity", "workflow", "custom.wsdl");
-        keystoreFilePath = Paths.get("/com", "sun", "identity", "workflow", "keystore.jks");
         outputWarFile = Files.createTempFile("soap-sts", "war").toFile();
     }
 
@@ -117,7 +118,7 @@ public class CreateSoapSTSDeploymentTest {
     }
 
     private void verifyGeneratedWarCorrectness(boolean withKeystoreFile, boolean withCustomWsdl) throws IOException {
-        try (JarInputStream jarInputStream  = new JarInputStream(getClass().getResourceAsStream(inputWarFilePath.toString()))) {
+        try (JarInputStream jarInputStream  = new JarInputStream(getClass().getResourceAsStream(INPUT_WAR_RESOURCE))) {
             final JarFile outputWar = new JarFile(outputWarFile);
             assertEquals(getJarInputStreamEntryNames(jarInputStream), getNonAddedOutputWarFileEntryNames(outputWar));
             assertNotNull(jarInputStream.getManifest());
@@ -142,7 +143,7 @@ public class CreateSoapSTSDeploymentTest {
     }
 
     private void verifyCustomWsdlFileCorrectness(JarFile outputWar) throws IOException {
-        try (InputStream inputWsdlStream = getClass().getResourceAsStream(customWsdlFilePath.toString());
+        try (InputStream inputWsdlStream = getClass().getResourceAsStream(CUSTOM_WSDL_RESOURCE);
              InputStream fromWarInputStream = outputWar.getInputStream(outputWar.getJarEntry(WEB_INF_CLASSES + WSDL_FILE_NAMES_PARAM_VALUE))) {
             final String customWsdlInput = readStringFromInputStream(inputWsdlStream);
             final String customWsdlInWar = readStringFromInputStream(fromWarInputStream);
@@ -238,7 +239,7 @@ public class CreateSoapSTSDeploymentTest {
         @Override
         protected JarInputStream getJarInputStream() throws WorkflowException {
             try {
-                return new JarInputStream(getClass().getResourceAsStream(inputWarFilePath.toString()));
+                return new JarInputStream(getClass().getResourceAsStream(INPUT_WAR_RESOURCE));
             } catch (IOException e) {
                 throw new WorkflowException("error opening test resource .war file: " + e);
             }
@@ -271,9 +272,9 @@ public class CreateSoapSTSDeploymentTest {
         @Override
         protected InputStream getInputStreamForKeystoreFileOrCustomWsdlFile(String fileName) throws IOException {
             if (WSDL_FILE_NAMES_PARAM_VALUE.equals(fileName)) {
-                return getClass().getResourceAsStream(customWsdlFilePath.toString());
+                return getClass().getResourceAsStream(CUSTOM_WSDL_RESOURCE);
             } else if (KEYSTORE_FILE_NAMES_PARAM_VALUE.equals(fileName)) {
-                return getClass().getResourceAsStream(keystoreFilePath.toString());
+                return getClass().getResourceAsStream(KEYSTORE_RESOURCE);
             }
             throw new IllegalStateException("Unexpected fileName parameter in " +
                     "MyCreateSoapSTSDeployment#getInputStreamForKeystoreFileOrCustomWsdlFile: " + fileName);

--- a/openam-federation/OpenFM/src/test/resources/eUnitTest.data
+++ b/openam-federation/OpenFM/src/test/resources/eUnitTest.data
@@ -1,0 +1,2 @@
+Line1
+Line2

--- a/openam-federation/OpenFM/src/test/resources/resourceNameIndexHost.properties
+++ b/openam-federation/OpenFM/src/test/resources/resourceNameIndexHost.properties
@@ -1,0 +1,40 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2009 Sun Microsystems Inc. All Rights Reserved
+#
+# The contents of this file are subject to the terms
+# of the Common Development and Distribution License
+# (the License). You may not use this file except in
+# compliance with the License.
+#
+# You can obtain a copy of the License at
+# https://opensso.dev.java.net/public/CDDLv1.0.html or
+# opensso/legal/CDDLv1.0.txt
+# See the License for the specific language governing
+# permission and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL
+# Header Notice in each file and include the License file
+# at opensso/legal/CDDLv1.0.txt.
+# If applicable, add the following below the CDDL Header,
+# with the fields enclosed by brackets [] replaced by
+# your own identifying information:
+# "Portions Copyrighted [year] [name of copyright owner]"
+#
+# $Id: resourceNameIndexHost.properties,v 1.1 2009/08/19 05:40:59 veiming Exp $
+#
+
+http\://www.sun.com/=://www.sun.com
+http\://www.*.com/test=://.com
+http\://*.sun.com/test.html=://.sun.com
+http\://www.sun.c*m\:8080/test/=://
+http\://www.sun.com\:8080/*/banner.htm=://www.sun.com
+http\://www.sun.com\:8080/test/*/banner.htm=://www.sun.com
+http\://www.sun.com\:8080/test?q1\=1=://www.sun.com
+http\://www.sun.com\:8080/-*-/test.jsp?q1\=1&q2\=2=://www.sun.com
+http\://www.sun.com\:8080/test.jsp?q2\=2&q1\=1=://www.sun.com
+http\://www.sun.com\:8080/test.jsp?q1\=*&q1\=1=://www.sun.com
+http\://www.sun.com\:8080/*/private/test.jsp?q1\=*&q1\=1=://www.sun.com
+http\://www.sun.com\:8080/test.jsp?q*\=2&q1\=1=://www.sun.com
+http\://www.sun.com\:8080/test.jsp?q1\=*&q*\=1=://www.sun.com
+http\://www.SUN.com\:8080/test.jsp?q1\=*&q*\=1=://www.sun.com

--- a/openam-federation/OpenFM/src/test/resources/resourceNameIndexPathParent.properties
+++ b/openam-federation/OpenFM/src/test/resources/resourceNameIndexPathParent.properties
@@ -1,0 +1,37 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2009 Sun Microsystems Inc. All Rights Reserved
+#
+# The contents of this file are subject to the terms
+# of the Common Development and Distribution License
+# (the License). You may not use this file except in
+# compliance with the License.
+#
+# You can obtain a copy of the License at
+# https://opensso.dev.java.net/public/CDDLv1.0.html or
+# opensso/legal/CDDLv1.0.txt
+# See the License for the specific language governing
+# permission and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL
+# Header Notice in each file and include the License file
+# at opensso/legal/CDDLv1.0.txt.
+# If applicable, add the following below the CDDL Header,
+# with the fields enclosed by brackets [] replaced by
+# your own identifying information:
+# "Portions Copyrighted [year] [name of copyright owner]"
+#
+# $Id: resourceNameIndexPathParent.properties,v 1.1 2009/08/19 05:40:59 veiming Exp $
+#
+
+http\://www.sun.com/=/
+http\://www.*.com/test=/
+http\://*.sun.com/test.html=/
+http\://www.sun.c*m\:8080/test/=/
+http\://www.sun.com\:8080/*/banner.htm=/
+http\://www.sun.com\:8080/-*-/test.jsp?q1\=1&q2\=2=/
+http\://www.sun.com\:8080/test.jsp?q2\=2&q1\=1=/
+http\://www.sun.com\:8080/test.jsp?q1\=*&q1\=1=/
+http\://www.sun.com\:8080/private/test.jsp?q1\=*&q1\=1=/private,/private/test.jsp
+http\://www.sun.com\:8080/private/john/test.jsp=/private,/private/john
+http\://www.sun.com\:8080/private/john/test.jsp?q1\=*&q1\=1=/private,/private/john,/private/john/test.jsp

--- a/openam-federation/OpenFM/src/test/resources/resourceNameIndexURI.properties
+++ b/openam-federation/OpenFM/src/test/resources/resourceNameIndexURI.properties
@@ -1,0 +1,42 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2009 Sun Microsystems Inc. All Rights Reserved
+#
+# The contents of this file are subject to the terms
+# of the Common Development and Distribution License
+# (the License). You may not use this file except in
+# compliance with the License.
+#
+# You can obtain a copy of the License at
+# https://opensso.dev.java.net/public/CDDLv1.0.html or
+# opensso/legal/CDDLv1.0.txt
+# See the License for the specific language governing
+# permission and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL
+# Header Notice in each file and include the License file
+# at opensso/legal/CDDLv1.0.txt.
+# If applicable, add the following below the CDDL Header,
+# with the fields enclosed by brackets [] replaced by
+# your own identifying information:
+# "Portions Copyrighted [year] [name of copyright owner]"
+#
+# $Id: resourceNameIndexURI.properties,v 1.1 2009/08/19 05:40:59 veiming Exp $
+#
+
+http\://www.sun.com/=/
+http\://www.*.com/test=/test
+http\://*.sun.com/test.html=/test.html
+http\://www.sun.c*m\:8080/test/=/test/
+http\://www.sun.com\:8080/*/banner.htm=/
+http\://www.sun.com\:8080/test/*/banner.htm=/test
+http\://www.sun.com\:8080/test?q1\=1=/test?q1=1
+http\://www.sun.com\:8080/-*-/test.jsp?q1\=1&q2\=2=/
+http\://www.sun.com\:8080/test.jsp?q2\=2&q1\=1=/test.jsp?q1=1&q2=2
+http\://www.sun.com\:8080/test.jsp?q1\=*&q1\=1=/test.jsp?q1=
+http\://www.sun.com\:8080/*/private/test.jsp?q1\=*&q1\=1=/
+http\://www.sun.com\:8080/test.jsp?q*\=2&q1\=1=/test.jsp
+http\://www.sun.com\:8080/test.jsp?q1\=*&q*\=1=/test.jsp
+http\://www.sun.com\:8080/TEST.jsp?q1\=*&q*\=1=/test.jsp
+http\://www.sun.com\:8080/*/private/test.jsp?Q1\=*&q1\=1=/
+

--- a/openam-federation/OpenFM/src/test/resources/resourceNameSplitHost.properties
+++ b/openam-federation/OpenFM/src/test/resources/resourceNameSplitHost.properties
@@ -1,0 +1,48 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2009 Sun Microsystems Inc. All Rights Reserved
+#
+# The contents of this file are subject to the terms
+# of the Common Development and Distribution License
+# (the License). You may not use this file except in
+# compliance with the License.
+#
+# You can obtain a copy of the License at
+# https://opensso.dev.java.net/public/CDDLv1.0.html or
+# opensso/legal/CDDLv1.0.txt
+# See the License for the specific language governing
+# permission and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL
+# Header Notice in each file and include the License file
+# at opensso/legal/CDDLv1.0.txt.
+# If applicable, add the following below the CDDL Header,
+# with the fields enclosed by brackets [] replaced by
+# your own identifying information:
+# "Portions Copyrighted [year] [name of copyright owner]"
+#
+# $Id: resourceNameSplitHost.properties,v 1.1 2009/08/19 05:40:59 veiming Exp $
+#
+# Portions Copyrighted 2026 3A Systems, LLC
+#
+# Host indexes are scheme-agnostic: splitHost() emits "://" rather than the
+# resource's own scheme, so a policy on http://host is indexed identically to
+# one on https://host. Every entry below therefore expects the same index set,
+# and www.SUN.com collapses onto www.sun.com because the host is lower-cased.
+
+http\://www.sun.com/=://,://www.sun.com,://.sun.com,://.com
+http\://www.sun.com/test=://,://www.sun.com,://.sun.com,://.com
+http\://www.sun.com/test.html=://,://www.sun.com,://.sun.com,://.com
+http\://www.sun.com\:8080/test/=://,://www.sun.com,://.sun.com,://.com
+http\://www.sun.com\:8080/test/banner.htm=://,://www.sun.com,://.sun.com,://.com
+http\://www.sun.com\:8080/?q1\=1=://,://www.sun.com,://.sun.com,://.com
+http\://www.sun.com\:8080/test?q1\=1=://,://www.sun.com,://.sun.com,://.com
+http\://www.sun.com\:8080/test.jsp?q1\=1&q2\=2=://,://www.sun.com,://.sun.com,://.com
+http\://www.sun.com\:8080/test.jsp?q2\=2&q1\=1=://,://www.sun.com,://.sun.com,://.com
+http\://www.sun.com\:8080/test.jsp?q1\=2&q1\=1=://,://www.sun.com,://.sun.com,://.com
+https\://www.sun.com/?q1\=1=://,://www.sun.com,://.sun.com,://.com
+https\://www.sun.com\:8080/test?q1\=1=://,://www.sun.com,://.sun.com,://.com
+https\://www.sun.com\:8080/test.jsp?q1\=1&q2\=2=://,://www.sun.com,://.sun.com,://.com
+https\://www.sun.com\:8080/test.jsp?q2\=2&q1\=1=://,://www.sun.com,://.sun.com,://.com
+https\://www.sun.com\:8080/test.jsp?q1\=2&q1\=1=://,://www.sun.com,://.sun.com,://.com
+https\://www.SUN.com\:8080/test.jsp?q1\=2&q1\=1=://,://www.sun.com,://.sun.com,://.com

--- a/openam-federation/OpenFM/src/test/resources/resourceNameSplitURI.properties
+++ b/openam-federation/OpenFM/src/test/resources/resourceNameSplitURI.properties
@@ -1,0 +1,43 @@
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2009 Sun Microsystems Inc. All Rights Reserved
+#
+# The contents of this file are subject to the terms
+# of the Common Development and Distribution License
+# (the License). You may not use this file except in
+# compliance with the License.
+#
+# You can obtain a copy of the License at
+# https\://opensso.dev.java.net/public/CDDLv1.0.html or
+# opensso/legal/CDDLv1.0.txt
+# See the License for the specific language governing
+# permission and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL
+# Header Notice in each file and include the License file
+# at opensso/legal/CDDLv1.0.txt.
+# If applicable, add the following below the CDDL Header,
+# with the fields enclosed by brackets [] replaced by
+# your own identifying information\:
+# "Portions Copyrighted [year] [name of copyright owner]"
+#
+# $Id: resourceNameSplitURI.properties,v 1.1 2009/08/19 05:40:59 veiming Exp $
+#
+
+http\://www.sun.com/=/
+http\://www.sun.com/test=/,/test
+http\://www.sun.com/test.html=/,/test.html
+http\://www.sun.com\:8080/test/=/,/test
+http\://www.sun.com\:8080/test/banner.htm=/,/test,/test/banner.htm
+http\://www.sun.com\:8080/?q1\=1=/,/?q1=1,/?q1=
+http\://www.sun.com\:8080/test?q1\=1=/,/test,/test?q1=,/test?q1=1,/?q1=,/?q1=1
+http\://www.sun.com\:8080/test.jsp?q1\=1&q2\=2=/,/test.jsp,/test.jsp?q1=&q2=2,/test.jsp?q1=1&q2=2,/test.jsp?q1=&q2=,/test.jsp?q1=1&q2=,/?q1=&q2=2,/?q1=1&q2=2,/?q1=&q2=,/?q1=1&q2=
+http\://www.sun.com\:8080/test.jsp?q2\=2&q1\=1=/,/test.jsp,/test.jsp?q1=&q2=2,/test.jsp?q1=1&q2=2,/test.jsp?q1=&q2=,/test.jsp?q1=1&q2=,/?q1=&q2=2,/?q1=1&q2=2,/?q1=&q2=,/?q1=1&q2=
+http\://www.sun.com\:8080/test.jsp?q1\=2&q1\=1=/,/test.jsp,/test.jsp?q1=1&q1=2,/test.jsp?q1=,/?q1=,/?q1=1&q1=2 
+https\://www.sun.com/?q1\=1=/,/?q1=1,/?q1=
+https\://www.sun.com\:8080/test?q1\=1=/,/test,/test?q1=,/test?q1=1,/?q1=,/?q1=1
+https\://www.sun.com\:8080/test.jsp?q1\=1&q2\=2=/,/test.jsp,/test.jsp?q1=&q2=2,/test.jsp?q1=1&q2=2,/test.jsp?q1=&q2=,/test.jsp?q1=1&q2=,/?q1=&q2=2,/?q1=1&q2=2,/?q1=&q2=,/?q1=1&q2=
+https\://www.sun.com\:8080/test.jsp?q2\=2&q1\=1=/,/test.jsp,/test.jsp?q1=&q2=2,/test.jsp?q1=1&q2=2,/test.jsp?q1=&q2=,/test.jsp?q1=1&q2=,/?q1=&q2=2,/?q1=1&q2=2,/?q1=&q2=,/?q1=1&q2=
+https\://www.sun.com\:8080/test.jsp?q1\=2&q1\=1=/,/test.jsp,/test.jsp?q1=1&q1=2,/test.jsp?q1=,/?q1=1&q1=2,/?q1=
+https\://www.sun.com\:8080/TEST.jsp?Q1\=2&q1\=1=/,/test.jsp,/test.jsp?q1=1&q1=2,/test.jsp?q1=,/?q1=1&q1=2,/?q1=
+


### PR DESCRIPTION
OpenFM has carried a blanket `<skipTests>true</skipTests>` since [2bbaf3849b](https://github.com/OpenIdentityPlatform/OpenAM/commit/2bbaf3849b) (2013), hiding all **178** of its tests. `mvn test` on the module now runs **48 tests, all green**.

### Why the flag was there

The OpenSSO-era tests obtain an Application SSO token via `AdminTokenAction` and drive `ServiceManager`/`IdRepo` directly. Outside a configured server they fail in the constructor or `@BeforeClass`, and TestNG aborts the **entire** suite when one class cannot be instantiated — so a single server-dependent test hid all the others. `CreateSoapSTSDeploymentTest` documented this in a comment.

This replaces the blanket flag with an explicit surefire exclude list for the 53 server-dependent classes. `excludes` rather than `includes` is deliberate: a newly added test is still picked up by the default patterns, instead of silently not running — the trap that created this situation.

### A real defect in openam-core

Once running, `NotConditionTest` caught exactly what it was written for in 2014. `LogicalCondition.equals` read `this.eConditions` directly but called `object.getEConditions()`. `NotCondition` overrides that getter and keeps its condition in a separate field, which is always `null` in the parent — so the comparison always failed:

```
NotCondition.equals(self) = false      ->  true
List.contains(n)          = false      ->  true
List.remove(n)            = false      ->  true
```

This violates the reflexivity contract of `Object.equals`. `HashSet` happened to work only because it compares references first. `AndCondition`/`OrCondition` are unaffected — they do not override the getter. Present since 2012, invisible because the test never ran.

### Test-side fixes

- Restored six fixtures left behind in the OpenSSO tree during the Maven migration (`resourceNameIndex*`, `resourceNameSplit*`, `eUnitTest.data`).
- `ResourceNameSplitTest` declared `@Test public boolean testHost()`; TestNG silently ignores non-void methods — a leftover from the OpenSSO harness where `true` meant pass. Made them `void`.
- `resourceNameSplitHost.properties` expected scheme-carrying host indexes (`http://www.sun.com`), but every implementation in history emits scheme-agnostic `://www.sun.com`. The fixture was stale before it was ever run; updated to the real contract.
- `CreateSoapSTSDeploymentTest`: supply the retry params added in OPENAM-8772 (2016).
- `ConfigureSocialAuthNTest`: the crypto value was intentionally removed in OPENAM-5851 (2015) — the same commit documented "*If client_secret entered, entry is ignored*". The product is right here; the test expectation was stale.

### Verification

| Module | Tests |
|---|---|
| OpenFM (`mvn test`, no flags) | 48 ✅ (was 0) |
| openam-core | 1797 ✅ |
| openam-entitlements | 564 ✅ |
| openam-federation-library | 43 ✅ |

### Not in scope

The 53 excluded classes were designed to run **inside** a deployed OpenAM: `TestHarness.execute(HttpServletResponse, String)` was invoked by a servlet in the webapp and ran TestNG in-container. That servlet no longer exists — `TestHarness` is an orphan with no caller. Reviving them needs a new harness (rebuild the in-container entry point, rewrite as black-box REST/Selenium, or bootstrap the server stack in-JVM) and is a separate project. The exclude list is the inventory to work from.