### PR TITLE
Harden AuthXMLRequest.setPrincipal against arbitrary class instantiation (same pattern as GHSA-wg5r-wc3x-39vc)

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/authentication/server/AuthXMLRequest.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/server/AuthXMLRequest.java
@@ -281,7 +281,20 @@ public class AuthXMLRequest {
      */
     public void setPrincipal(String className,String principalValue) {
         try {
-            Class clName = Class.forName(className);
+            // className is read from the /authservice (PLL) request XML, so it must not be
+            // resolved with side effects. Load the class without running its static
+            // initializers and verify it is a Principal BEFORE instantiating it: the
+            // (Principal) cast below is evaluated only after newInstance() has already run
+            // the class's static initializer and constructor, so the cast is not a control.
+            // Same hardening as AuthXMLUtils.createCustomCallback
+            // (GHSA-wg5r-wc3x-39vc / CVE-2026-62379).
+            Class clName = Class.forName(className, false,
+                AuthXMLRequest.class.getClassLoader());
+            if (!Principal.class.isAssignableFrom(clName)) {
+                debug.error("AuthXMLRequest.setPrincipal : class " + className
+                    + " is not a java.security.Principal implementation");
+                return;
+            }
             principal = (Principal) clName.newInstance();
         } catch (ClassNotFoundException ce) {
             //debug.error("Error creating class instance " , e); 

--- a/openam-core/src/main/java/com/sun/identity/authentication/server/AuthXMLRequest.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/server/AuthXMLRequest.java
@@ -281,13 +281,14 @@ public class AuthXMLRequest {
      */
     public void setPrincipal(String className,String principalValue) {
         try {
-            // className is read from the /authservice (PLL) request XML, so it must not be
-            // resolved with side effects. Load the class without running its static
-            // initializers and verify it is a Principal BEFORE instantiating it: the
-            // (Principal) cast below is evaluated only after newInstance() has already run
-            // the class's static initializer and constructor, so the cast is not a control.
-            // Same hardening as AuthXMLUtils.createCustomCallback
-            // (GHSA-wg5r-wc3x-39vc / CVE-2026-62379).
+            // Nothing in the tree reaches this today: setPrincipal has no in-tree callers and
+            // AuthXMLTags.PRINCIPAL is declared but never parsed into it. It is public API on a
+            // request object, though, so it is held to the same contract as
+            // AuthXMLUtils.createCustomCallback after GHSA-wg5r-wc3x-39vc / CVE-2026-62379.
+            // Load the class without running its static initializers and verify it is a
+            // Principal BEFORE instantiating it: the (Principal) cast below is evaluated only
+            // after newInstance() has already run the class's static initializer and
+            // constructor, so the cast is not a control.
             Class clName = Class.forName(className, false,
                 AuthXMLRequest.class.getClassLoader());
             if (!Principal.class.isAssignableFrom(clName)) {

--- a/openam-core/src/test/java/com/sun/identity/authentication/server/AuthXMLRequestSecurityTest.java
+++ b/openam-core/src/test/java/com/sun/identity/authentication/server/AuthXMLRequestSecurityTest.java
@@ -1,0 +1,103 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ */
+
+package com.sun.identity.authentication.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.Principal;
+
+import org.testng.annotations.Test;
+
+/**
+ * setPrincipal(String, String) resolves a class by name. It is not reachable in-tree today, but it
+ * is public, so it is held to the same contract as AuthXMLUtils.createCustomCallback after
+ * GHSA-wg5r-wc3x-39vc: a class that is not a Principal must be rejected without being initialized
+ * or instantiated.
+ */
+public class AuthXMLRequestSecurityTest {
+
+    @Test
+    public void setPrincipalRejectsNonPrincipalClassWithoutLoadingOrInstantiatingIt() {
+        ProbeFlags.initialised = false;
+        ProbeFlags.instantiated = false;
+
+        AuthXMLRequest request = new AuthXMLRequest();
+        request.setPrincipal(NonPrincipalProbe.class.getName(), "ignored");
+
+        assertThat(request.getPrincipal())
+                .as("a class that is not a Principal must not become the principal").isNull();
+        assertThat(ProbeFlags.instantiated)
+                .as("the named class must never be instantiated").isFalse();
+        assertThat(ProbeFlags.initialised)
+                .as("the named class must not even be initialized: Class.forName must be called"
+                        + " with initialize=false so an unvalidated name cannot run a static"
+                        + " initializer").isFalse();
+    }
+
+    @Test
+    public void setPrincipalStillAcceptsALegitimatePrincipal() {
+        AuthXMLRequest request = new AuthXMLRequest();
+        request.setPrincipal(LegitimatePrincipal.class.getName(), "ignored");
+
+        assertThat(request.getPrincipal())
+                .as("a genuine Principal implementation must still resolve")
+                .isInstanceOf(LegitimatePrincipal.class);
+    }
+
+    @Test
+    public void setPrincipalIgnoresAnUnknownClassName() {
+        AuthXMLRequest request = new AuthXMLRequest();
+        request.setPrincipal("com.example.NoSuchClassAnywhere", "ignored");
+
+        assertThat(request.getPrincipal()).isNull();
+    }
+
+    /**
+     * The flags live outside the probe on purpose. Reading or writing a static field of a class
+     * triggers that class's initialization, so flags held on the probe itself would be set by the
+     * test's own reset, and the "was it initialized" assertion would pass even against the
+     * unhardened code. Keeping them here means the probe is only ever named by a class literal,
+     * which does not trigger initialization, so the assertion can actually fail.
+     */
+    static final class ProbeFlags {
+
+        static volatile boolean initialised;
+        static volatile boolean instantiated;
+
+        private ProbeFlags() {
+        }
+    }
+
+    /** Not a Principal. Records, elsewhere, whether it was initialized or constructed. */
+    public static class NonPrincipalProbe {
+
+        static {
+            ProbeFlags.initialised = true;
+        }
+
+        public NonPrincipalProbe() {
+            ProbeFlags.instantiated = true;
+        }
+    }
+
+    /** A minimal genuine Principal, to show the guard is not over-broad. */
+    public static class LegitimatePrincipal implements Principal {
+
+        @Override
+        public String getName() {
+            return "legitimate";
+        }
+    }
+}


### PR DESCRIPTION
### What

`AuthXMLRequest.setPrincipal(String, String)` resolves and instantiates a class named by its `className` argument:

```java
public void setPrincipal(String className, String principalValue) {
    try {
        Class clName = Class.forName(className);
        principal = (Principal) clName.newInstance();
    } catch (ClassNotFoundException ce) {
    } catch (IllegalAccessException ia) {
    } catch (InstantiationException ie) {
    } catch (Exception e) {
    }
}
```

This is the same shape `AuthXMLUtils.createCustomCallback` had before edcf968c (GHSA-wg5r-wc3x-39vc / CVE-2026-62379). This PR applies the same hardening you used there: resolve with `initialize=false`, and confirm the class is a `Principal` **before** `newInstance()`.

### Why the existing cast is not a control

The `(Principal)` cast is evaluated only *after* `newInstance()` returns, so the named class's static initializer and no-arg constructor have both already run by the time the cast can reject it. The one-argument `Class.forName` also defaults to `initialize=true`, so a static initializer runs at resolution time even when no instance is ever created. Checked in an isolated JVM:

```
Class.forName(name) then (Iface) c.newInstance()       ->  [static initializer RAN]
                                                          [constructor RAN]
                                                          ClassCastException
Class.forName(name, false, loader) + isAssignableFrom  ->  rejected, neither ran
```

Two details specific to this method:

- **Every exception is swallowed by empty `catch` blocks**, including the `ClassCastException`. Side effects from loading a caller-named class would leave no trace in the logs at all — unlike `createCustomCallback`, which at least reached `debug.error`.
- **`principalValue` is never used.** It appears in the signature and the Javadoc, and nowhere in the body.

### This is not a vulnerability report and needs no advisory

Stating this plainly so it is not routed as a security disclosure:

- `AuthXMLRequest` is referenced by five files, all in `openam-core` — itself, `AuthXMLRequestParser`, `AuthXMLResponse`, `AuthXMLHandler` and `AuthUtils` — and **none calls `setPrincipal`**. I checked the whole monorepo: the other `setPrincipal` matches are `com.iplanet.ums.*` `setPrincipal(Principal)` plus unrelated single-argument methods in `openam-federation`, `openam-sts` and `openam-auth-windowsdesktopsso`.
- With no reachable path there is no attacker model, so **no CVE and no advisory are warranted**, and I am not requesting either. This is defence in depth on a `public` method that is one caller away from being live, in a class that reached `Class.forName(caller_string).newInstance()` under CVE-2026-62379.
- Limits of my own claim: reachability was assessed statically against this repository and the published `openam-core` 16.1.1 / 16.1.2 artifacts. I have no visibility into downstream integrations, and `setPrincipal` is `public` on a `public` class, so an external caller may exist.

### You may prefer to delete it instead

The method is unreachable in-tree and ignores its second parameter, so removing it outright is arguably the better change and I am happy to switch this PR to a deletion. I proposed hardening because deleting a `public` method on a `public` class is a breaking change for any downstream caller, and that trade-off is yours. Say which you would prefer.

### Testing

Adds `AuthXMLRequestSecurityTest`, following the structure of the `AuthXMLUtilsSecurityTest` added in edcf968c (TestNG + AssertJ, probe class with static flags). It asserts a non-`Principal` class is neither initialized nor instantiated, and that a legitimate `Principal` still resolves.

One design note worth flagging, because the obvious version of this test silently passes against the unhardened code: the probe's flags live in a **separate holder class**. Reading or writing a static field triggers that class's initialization, so flags stored on the probe itself get set by the test's own reset, and the "was it initialized" assertion then passes no matter what `forName` does. With the flags held elsewhere the probe is only ever named by a class literal, which does not trigger initialization. I verified both assertions fail against the 1-argument `Class.forName` shape and pass with this change.

I have not been able to run the module's full test suite locally (the build needs JDK 17 and this host has 16), so please treat CI as the authority on that.
