### PR TITLE
CVE-2026-18446 fast-uri vulnerable to host confusion via backslash authority introducer

### DIFF
--- a/openam-ui/openam-ui-js-sdk/package-lock.json
+++ b/openam-ui/openam-ui-js-sdk/package-lock.json
@@ -3109,9 +3109,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {

--- a/openam-ui/openam-ui-ria/package-lock.json
+++ b/openam-ui/openam-ui-ria/package-lock.json
@@ -3586,9 +3586,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Bumps `fast-uri` from 3.1.4 to 3.1.5 in both remaining modules, combining the two separate dependabot PRs into one change.

- `openam-ui/openam-ui-js-sdk/package-lock.json` (was #1096)
- `openam-ui/openam-ui-ria/package-lock.json` (was #1097)

`fast-uri` is a dev-scope transitive dependency (via `ajv`), used only by the UI build toolchain — it does not ship in the WAR.

Verified: the `integrity` hash matches `npm view fast-uri@3.1.5 dist.integrity`, and `npm install --package-lock-only --prefer-online` is a no-op on both modules, so the build will not roll the version back.

Closes #1096
Closes #1097