### PR TITLE
CVE-2026-13149 CVE-2026-14257 CVE-2026-69152 brace-expansion: DoS via unbounded expansion

### DIFF
--- a/openam-ui/openam-ui-api/package-lock.json
+++ b/openam-ui/openam-ui-api/package-lock.json
@@ -85,9 +85,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/openam-ui/openam-ui-js-sdk/package-lock.json
+++ b/openam-ui/openam-ui-js-sdk/package-lock.json
@@ -2551,16 +2551,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {

--- a/openam-ui/openam-ui-ria/package-lock.json
+++ b/openam-ui/openam-ui-ria/package-lock.json
@@ -2129,10 +2129,11 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"


### PR DESCRIPTION
Bumps the dev-scope transitive `brace-expansion` in all three `openam-ui` modules:

| module | from | to |
|---|---|---|
| `openam-ui-ria` | 1.1.12 | 1.1.18 |
| `openam-ui-api` | 1.1.12 | 1.1.18 |
| `openam-ui-js-sdk` | 5.0.7 | 5.0.9 |

Covers three advisories at once — GHSA-3jxr-9vmj-r5cp / CVE-2026-13149 (patched in 1.1.16), GHSA-mh99-v99m-4gvg / CVE-2026-14257 (1.1.17 / 5.0.8) and GHSA-rgw5-rvv9-x895 / CVE-2026-69152 (1.1.18 / 5.0.9).

`brace-expansion` is pulled in transitively by `minimatch` and is used only by the UI build toolchain — it does not ship in the WAR.

Lockfile-only change: both bumps stay inside the semver ranges the parent `minimatch` packages already declare (`^1.1.7` in ria/api, `^5.0.2`/`^5.0.5` in js-sdk), so no `overrides` entries are needed.

Verified:
- both `integrity` hashes match `npm view brace-expansion@<v> dist.integrity`
- `npm install --package-lock-only --prefer-online` is a no-op on all three modules, so the build will not roll the versions back
- `npm audit` no longer reports `brace-expansion` in any of the three modules
- `brace-expansion@5.0.9` raises `engines.node` from `18 || 20 || >=22` to `20 || >=22`; the build runs on `v22.21.1` (`openam-ui/pom.xml`), so it stays satisfied