### PR TITLE
CVE-2026-59869 js-yaml: YAML merge-key chains can force quadratic CPU consumption

### DIFF
--- a/openam-ui/openam-ui-api/package-lock.json
+++ b/openam-ui/openam-ui-api/package-lock.json
@@ -762,9 +762,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/openam-ui/openam-ui-api/package.json
+++ b/openam-ui/openam-ui-api/package.json
@@ -16,7 +16,7 @@
     "swagger-ui-dist": ">=5.29.0"
   },
   "overrides": {
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
     "grunt": {
       "lodash": "$lodash"
     }


### PR DESCRIPTION
Bumps `js-yaml` from 4.2.0 to 4.3.1 in `openam-ui-api` (GHSA-52cp-r559-cp3m / CVE-2026-59869, patched in 4.3.0).

Unlike the other recent dependency fixes this one needs a `package.json` change: `grunt@1.6.2` requires `~3.14.0`, so the version is governed by the existing `overrides` entry — and that entry (`"js-yaml": "^4.2.0"`) is exactly what pinned the package inside the vulnerable `>=4.0.0 <4.3.0` range. Raising it to `^4.3.0` resolves to 4.3.1.

Completes #1074, which applied the same fix to `openam-ui-ria` only.

`js-yaml` is a dev-scope transitive dependency of the UI build toolchain — it does not ship in the WAR.

Verified:
- the `integrity` hash matches `npm view js-yaml@4.3.1 dist.integrity`
- `npm install --package-lock-only --prefer-online` is a no-op, so the build will not roll the version back
- `npm audit` no longer reports `js-yaml` for this module
- the 3.x -> 4.x jump was already made by the pre-existing override; this is only a patch-level move inside 4.x. `grunt.file.readYAML` (which relies on the `safeLoad` removed in js-yaml 4) is not affected either way — `openam-ui-api/Gruntfile.js` does not read YAML at all