### PR TITLE
[#1103] Add upgrade step syncing missing ScriptingService sub-configurations

### DIFF
--- a/openam-core/src/main/resources/amUpgrade.properties
+++ b/openam-core/src/main/resources/amUpgrade.properties
@@ -23,6 +23,7 @@
 #
 
 # Portions Copyrighted 2014-2016 Nomura Research Institute, Ltd
+# Portions Copyright 2026 3A Systems, LLC.
 
 report=OpenAM Upgrade Report%LF%=====================%LF%Created: %CREATED_DATE%%LF%%LF%Existing Version: %EXISTING_VERSION%%LF%New Version: %NEW_VERSION%%LF%%LF%
 upgrade.servicereport=Services Upgrade Report%LF%-----------------------%LF%%LF%New Services%LF%%LF%%NEW_SERVICES%%LF%%LF%Modified Services%LF%%LF%%MODIFIED_SERVICES%%LF%%LF%New Schemas%LF%%LF%%NEW_SCHEMAS%%LF%%LF%New Sub Schemas%LF%%LF%%NEW_SUB_SCHEMAS%%LF%%LF%Deleted Services%LF%%LF%%DELETED_SERVICES%%LF%%LF%
@@ -164,6 +165,11 @@ upgrade.scripting.global.settings=Scripting Global Settings modified ({0})
 upgrade.scripting.global.context=Settings for {0} moved to {1}
 upgrade.scripting.global.engine.start=Upgrading Global Engine Configuration for script context: {0}
 upgrade.scripting.global.script.start=Upgrading default script to global script: {0}
+# Scripting service sub-configurations upgrade
+upgrade.scripting.subconfigs.report=Scripting Service Configuration Report%LF%--------------------------------------%LF%%REPORT_DATA%%LF%
+upgrade.scripting.subconfigs=New Scripting Service configurations ({0})
+upgrade.scripting.subconfigs.new=New Scripting Service configuration: {0}
+upgrade.scripting.subconfigs.new.start=Adding Scripting Service configuration: {0}
 
 # Update Post Authentication Plugins upgrade
 upgrade.postauthenticationplugins.short=Post Authentication Plugin classes to upgrade

--- a/openam-server-only/src/main/webapp/WEB-INF/template/sms/serverupgrade.properties
+++ b/openam-server-only/src/main/webapp/WEB-INF/template/sms/serverupgrade.properties
@@ -21,6 +21,8 @@
 # your own identifying information:
 # "Portions Copyrighted [year] [name of copyright owner]"
 #
+# Portions Copyright 2026 3A Systems, LLC.
+#
 
 defaults.to.upgrade=com.iplanet.am.version,com.iplanet.am.console.deploymentDescriptor,com.iplanet.am.daemons,\
   com.iplanet.am.buildVersion,com.iplanet.am.buildRevision,com.iplanet.am.buildDate
@@ -36,6 +38,7 @@ upgrade.helper=iPlanetAMLoggingService=org.forgerock.openam.upgrade.helpers.Logg
   sunAMAuthOAuthService=org.forgerock.openam.upgrade.helpers.OAuth2AuthModuleUpgradeHelper,\
   iPlanetAMAuthScriptedService=org.forgerock.openam.upgrade.helpers.ScriptedAuthHelper,\
   iPlanetAMAuthDeviceIdMatchService=org.forgerock.openam.upgrade.helpers.ScriptedAuthHelper,\
+  ScriptingService=org.forgerock.openam.upgrade.helpers.ScriptingServiceHelper,\
   AuditService=org.forgerock.openam.upgrade.helpers.AuditUpgradeHelper,\
   iPlanetAMAuthOpenIdConnectService=org.forgerock.openam.upgrade.helpers.OpenIdConnectAuthModuleServiceHelper,\
   sunFAMSAML2Configuration=org.forgerock.openam.upgrade.helpers.SAML2ConfigHelper,\

--- a/openam-server-only/src/main/webapp/WEB-INF/template/sms/serverupgrade.properties
+++ b/openam-server-only/src/main/webapp/WEB-INF/template/sms/serverupgrade.properties
@@ -46,6 +46,4 @@ upgrade.helper=iPlanetAMLoggingService=org.forgerock.openam.upgrade.helpers.Logg
   MailServer=org.forgerock.openam.upgrade.helpers.MailServiceUpgradeHelper,\
   iPlanetAMAuthAuthenticatorOATHService=org.forgerock.openam.upgrade.helpers.AuthAuthenticatorOathHelper
 services.to.delete=iPlanetAMAuthSafeWordService,iPlanetAMAuthUnixService,sunFAMLibertyInteractionService,sunFAMLibertySecurityService
-  RestSecurity=org.forgerock.openam.upgrade.helpers.UserSelfServiceHelper
-services.to.delete=iPlanetAMAuthSafeWordService,iPlanetAMAuthUnixService,sunFAMLibertyInteractionService,sunFAMLibertySecurityService
 

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/helpers/ScriptingServiceHelper.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/helpers/ScriptingServiceHelper.java
@@ -26,30 +26,35 @@ import com.sun.identity.sm.AbstractUpgradeHelper;
 import com.sun.identity.sm.AttributeSchemaImpl;
 
 /**
- * This upgrade helper keeps the script context choice values of the Scripting Service schema in sync with the
- * service definition, so that script contexts introduced in later versions become available on upgraded instances.
+ * This upgrade helper keeps the choice values of the Scripting Service {@code defaultScriptContext} attribute in
+ * sync with the service definition, so that script contexts introduced in later versions become available on
+ * upgraded instances. The administrator's configured default is preserved.
  */
 public class ScriptingServiceHelper extends AbstractUpgradeHelper {
 
     private static final String DEFAULT_SCRIPT_CONTEXT = "defaultScriptContext";
-    private static final String SCRIPT_CONTEXT = "context";
 
     /**
      * Default constructor
      */
     public ScriptingServiceHelper() {
         attributes.add(DEFAULT_SCRIPT_CONTEXT);
-        attributes.add(SCRIPT_CONTEXT);
     }
 
     @Override
     public AttributeSchemaImpl upgradeAttribute(AttributeSchemaImpl attributeToUpgrade,
             AttributeSchemaImpl attributeFromNewSchema) throws UpgradeException {
 
-        if (!asSet(attributeToUpgrade.getChoiceValues()).equals(asSet(attributeFromNewSchema.getChoiceValues()))) {
+        if (asSet(attributeToUpgrade.getChoiceValues()).equals(asSet(attributeFromNewSchema.getChoiceValues()))) {
+            return null;
+        }
+        // For Global attributes the administrator's configured value is persisted as the schema default, so
+        // carry it over instead of reverting to the default bundled in the service definition.
+        Set<String> existingDefaults = attributeToUpgrade.getDefaultValues();
+        if (existingDefaults.isEmpty()) {
             return attributeFromNewSchema;
         }
-        return null;
+        return updateDefaultValues(attributeFromNewSchema, existingDefaults);
     }
 
     private static Set<String> asSet(String[] values) {

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/helpers/ScriptingServiceHelper.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/helpers/ScriptingServiceHelper.java
@@ -1,0 +1,58 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.forgerock.openam.upgrade.helpers;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.forgerock.openam.upgrade.UpgradeException;
+
+import com.sun.identity.sm.AbstractUpgradeHelper;
+import com.sun.identity.sm.AttributeSchemaImpl;
+
+/**
+ * This upgrade helper keeps the script context choice values of the Scripting Service schema in sync with the
+ * service definition, so that script contexts introduced in later versions become available on upgraded instances.
+ */
+public class ScriptingServiceHelper extends AbstractUpgradeHelper {
+
+    private static final String DEFAULT_SCRIPT_CONTEXT = "defaultScriptContext";
+    private static final String SCRIPT_CONTEXT = "context";
+
+    /**
+     * Default constructor
+     */
+    public ScriptingServiceHelper() {
+        attributes.add(DEFAULT_SCRIPT_CONTEXT);
+        attributes.add(SCRIPT_CONTEXT);
+    }
+
+    @Override
+    public AttributeSchemaImpl upgradeAttribute(AttributeSchemaImpl attributeToUpgrade,
+            AttributeSchemaImpl attributeFromNewSchema) throws UpgradeException {
+
+        if (!asSet(attributeToUpgrade.getChoiceValues()).equals(asSet(attributeFromNewSchema.getChoiceValues()))) {
+            return attributeFromNewSchema;
+        }
+        return null;
+    }
+
+    private static Set<String> asSet(String[] values) {
+        return values == null ? Collections.<String>emptySet() : new HashSet<>(Arrays.asList(values));
+    }
+}

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/UpgradeServiceUtils.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/UpgradeServiceUtils.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC.
  */
 
 package org.forgerock.openam.upgrade.steps;
@@ -59,7 +60,7 @@ public class UpgradeServiceUtils {
      * @return A map of service name to the service DOM models.
      * @throws UpgradeException When the service XML cannot be loaded.
      */
-    static Map<String, Document> getServiceDefinitions(SSOToken token) throws UpgradeException {
+    public static Map<String, Document> getServiceDefinitions(SSOToken token) throws UpgradeException {
         List<String> serviceNames = new ArrayList<>();
         serviceNames.addAll(UpgradeUtils.getPropertyValues(SetupConstants.PROPERTY_FILENAME,
                 SetupConstants.SERVICE_NAMES));

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/scripting/UpgradeScriptingSubConfigsStep.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/scripting/UpgradeScriptingSubConfigsStep.java
@@ -58,6 +58,10 @@ import com.sun.identity.sm.ServiceNotFoundException;
  * are added to it. New script contexts are only registered by the SMS when the whole service is new, so instances
  * upgraded from a version that already contained the Scripting Service would otherwise be left without the
  * configuration for contexts introduced in later versions (see OPENAM issue #1103).
+ * <p>
+ * The step only creates missing sub-configurations; attributes of existing sub-configurations are never
+ * reconciled with the service definition, so changes to e.g. an existing engine configuration whitelist do not
+ * reach upgraded instances.
  */
 @UpgradeStepInfo(dependsOn = "org.forgerock.openam.upgrade.steps.UpgradeServiceSchemaStep")
 public class UpgradeScriptingSubConfigsStep extends AbstractUpgradeStep {
@@ -72,6 +76,11 @@ public class UpgradeScriptingSubConfigsStep extends AbstractUpgradeStep {
     private static final String AUDIT_NEW_SUB_CONFIG_START = "upgrade.scripting.subconfigs.new.start";
 
     private final List<MissingSubConfig> missingSubConfigs = new ArrayList<>();
+    /**
+     * Display names of every sub-configuration that will be created, including descendants of the missing nodes.
+     * Only used for reporting; {@link #perform()} creates descendants by recursing into the missing nodes.
+     */
+    private final List<String> reportedSubConfigs = new ArrayList<>();
 
     @Inject
     public UpgradeScriptingSubConfigsStep(PrivilegedAction<SSOToken> adminTokenAction,
@@ -102,7 +111,16 @@ public class UpgradeScriptingSubConfigsStep extends AbstractUpgradeStep {
     }
 
     private Node getGlobalConfigurationNode(Document scriptingDocument) {
-        return scriptingDocument.getElementsByTagName(SMSUtils.GLOBAL_CONFIG).item(0);
+        for (Iterator it = XMLUtils.getChildNodes(scriptingDocument.getDocumentElement(), SMSUtils.SERVICE).iterator();
+                it.hasNext();) {
+            Node serviceNode = (Node) it.next();
+            if (SCRIPTING_SERVICE_NAME.equals(XMLUtils.getNodeAttributeValue(serviceNode, NAME))) {
+                Node configurationNode = XMLUtils.getChildNode(serviceNode, SMSUtils.CONFIGURATION);
+                return configurationNode == null ? null : XMLUtils.getChildNode(configurationNode,
+                        SMSUtils.GLOBAL_CONFIG);
+            }
+        }
+        return null;
     }
 
     private void captureMissingSubConfigs(Node parentNode, ServiceConfig parentConfig, List<String> parentPath)
@@ -110,14 +128,27 @@ public class UpgradeScriptingSubConfigsStep extends AbstractUpgradeStep {
         for (Iterator it = XMLUtils.getChildNodes(parentNode, SMSUtils.SUB_CONFIG).iterator(); it.hasNext();) {
             Node node = (Node) it.next();
             String name = XMLUtils.getNodeAttributeValue(node, NAME);
+            // For an absent entry getSubConfig may return a non-null config wrapping a non-existent SMSEntry
+            // when the sub-config name matches a sub-schema name (e.g. engineConfiguration, globalScripts),
+            // so presence must be determined via ServiceConfig#exists.
             ServiceConfig existingConfig = parentConfig.getSubConfig(name);
-            if (existingConfig == null) {
-                missingSubConfigs.add(new MissingSubConfig(new ArrayList<>(parentPath), name, node));
+            if (!SMSUtils.serviceExists(existingConfig)) {
+                MissingSubConfig missing = new MissingSubConfig(new ArrayList<>(parentPath), name, node);
+                missingSubConfigs.add(missing);
+                reportSubConfigTree(missing.getDisplayName(), node);
             } else {
                 parentPath.add(name);
                 captureMissingSubConfigs(node, existingConfig, parentPath);
                 parentPath.remove(parentPath.size() - 1);
             }
+        }
+    }
+
+    private void reportSubConfigTree(String displayName, Node node) {
+        reportedSubConfigs.add(displayName);
+        for (Iterator it = XMLUtils.getChildNodes(node, SMSUtils.SUB_CONFIG).iterator(); it.hasNext();) {
+            Node child = (Node) it.next();
+            reportSubConfigTree(displayName + '/' + XMLUtils.getNodeAttributeValue(child, NAME), child);
         }
     }
 
@@ -135,11 +166,22 @@ public class UpgradeScriptingSubConfigsStep extends AbstractUpgradeStep {
                 ServiceConfig parentConfig = globalConfig;
                 for (String parentName : missing.parentPath) {
                     parentConfig = parentConfig.getSubConfig(parentName);
+                    if (parentConfig == null) {
+                        throw new UpgradeException("Missing parent configuration for " + missing.getDisplayName());
+                    }
                 }
-                addSubConfig(parentConfig, missing.node);
+                // The missing list was captured in initialize(); the entry may have been created since.
+                if (SMSUtils.serviceExists(parentConfig.getSubConfig(missing.name))) {
+                    DEBUG.message("Scripting Service configuration {} already exists, skipping", missing.name);
+                } else {
+                    addSubConfig(parentConfig, missing.node);
+                }
                 UpgradeProgress.reportEnd("upgrade.success");
             }
-        } catch (SMSException | SSOException e) {
+        } catch (UpgradeException e) {
+            UpgradeProgress.reportEnd("upgrade.failed");
+            throw e;
+        } catch (Exception e) {
             UpgradeProgress.reportEnd("upgrade.failed");
             DEBUG.error("An error occurred while adding missing Scripting Service configurations", e);
             throw new UpgradeException("Unable to add missing Scripting Service configurations", e);
@@ -170,8 +212,8 @@ public class UpgradeScriptingSubConfigsStep extends AbstractUpgradeStep {
     @Override
     public String getShortReport(String delimiter) {
         StringBuilder sb = new StringBuilder();
-        if (!missingSubConfigs.isEmpty()) {
-            sb.append(MessageFormat.format(BUNDLE.getString(AUDIT_NEW_SUB_CONFIGS), missingSubConfigs.size()));
+        if (!reportedSubConfigs.isEmpty()) {
+            sb.append(MessageFormat.format(BUNDLE.getString(AUDIT_NEW_SUB_CONFIGS), reportedSubConfigs.size()));
             sb.append(delimiter);
         }
         return sb.toString();
@@ -183,9 +225,9 @@ public class UpgradeScriptingSubConfigsStep extends AbstractUpgradeStep {
         tags.put(LF, delimiter);
 
         StringBuilder sb = new StringBuilder();
-        for (MissingSubConfig missing : missingSubConfigs) {
+        for (String displayName : reportedSubConfigs) {
             sb.append(INDENT);
-            sb.append(MessageFormat.format(BUNDLE.getString(AUDIT_NEW_SUB_CONFIG), missing.getDisplayName()));
+            sb.append(MessageFormat.format(BUNDLE.getString(AUDIT_NEW_SUB_CONFIG), displayName));
             sb.append(delimiter);
         }
         tags.put("%REPORT_DATA%", sb.toString());

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/scripting/UpgradeScriptingSubConfigsStep.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/scripting/UpgradeScriptingSubConfigsStep.java
@@ -1,0 +1,238 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.forgerock.openam.upgrade.steps.scripting;
+
+import static org.forgerock.openam.upgrade.UpgradeServices.LF;
+import static org.forgerock.openam.upgrade.UpgradeServices.tagSwapReport;
+
+import java.security.PrivilegedAction;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+
+import org.forgerock.openam.sm.datalayer.api.ConnectionFactory;
+import org.forgerock.openam.sm.datalayer.api.ConnectionType;
+import org.forgerock.openam.sm.datalayer.api.DataLayer;
+import org.forgerock.openam.upgrade.UpgradeException;
+import org.forgerock.openam.upgrade.UpgradeProgress;
+import org.forgerock.openam.upgrade.UpgradeStepInfo;
+import org.forgerock.openam.upgrade.steps.AbstractUpgradeStep;
+import org.forgerock.openam.upgrade.steps.UpgradeServiceUtils;
+import org.forgerock.openam.utils.StringUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import com.iplanet.sso.SSOException;
+import com.iplanet.sso.SSOToken;
+import com.sun.identity.shared.xml.XMLUtils;
+import com.sun.identity.sm.CreateServiceConfig;
+import com.sun.identity.sm.SMSException;
+import com.sun.identity.sm.SMSUtils;
+import com.sun.identity.sm.ServiceConfig;
+import com.sun.identity.sm.ServiceConfigManager;
+import com.sun.identity.sm.ServiceNotFoundException;
+
+/**
+ * This upgrade step ensures that any global sub-configurations defined in scripting.xml (script contexts with
+ * their engine configurations, and the default global scripts) that are missing from the configuration data store
+ * are added to it. New script contexts are only registered by the SMS when the whole service is new, so instances
+ * upgraded from a version that already contained the Scripting Service would otherwise be left without the
+ * configuration for contexts introduced in later versions (see OPENAM issue #1103).
+ */
+@UpgradeStepInfo(dependsOn = "org.forgerock.openam.upgrade.steps.UpgradeServiceSchemaStep")
+public class UpgradeScriptingSubConfigsStep extends AbstractUpgradeStep {
+
+    private static final String SCRIPTING_SERVICE_NAME = "ScriptingService";
+    private static final String NAME = "name";
+    private static final String ID = "id";
+    private static final String PRIORITY = "priority";
+    private static final String AUDIT_REPORT = "upgrade.scripting.subconfigs.report";
+    private static final String AUDIT_NEW_SUB_CONFIGS = "upgrade.scripting.subconfigs";
+    private static final String AUDIT_NEW_SUB_CONFIG = "upgrade.scripting.subconfigs.new";
+    private static final String AUDIT_NEW_SUB_CONFIG_START = "upgrade.scripting.subconfigs.new.start";
+
+    private final List<MissingSubConfig> missingSubConfigs = new ArrayList<>();
+
+    @Inject
+    public UpgradeScriptingSubConfigsStep(PrivilegedAction<SSOToken> adminTokenAction,
+            @DataLayer(ConnectionType.DATA_LAYER) ConnectionFactory connectionFactory) {
+        super(adminTokenAction, connectionFactory);
+    }
+
+    @Override
+    public void initialize() throws UpgradeException {
+        try {
+            ServiceConfig globalConfig = getScriptingGlobalConfig();
+            if (globalConfig == null) {
+                DEBUG.message("No global configuration found for {}. Nothing to upgrade", SCRIPTING_SERVICE_NAME);
+                return;
+            }
+            Node globalConfigNode = getGlobalConfigurationNode(getScriptingServiceXML());
+            if (globalConfigNode == null) {
+                DEBUG.message("No global configuration defined in the {} service definition", SCRIPTING_SERVICE_NAME);
+                return;
+            }
+            captureMissingSubConfigs(globalConfigNode, globalConfig, new ArrayList<String>());
+        } catch (ServiceNotFoundException e) {
+            DEBUG.message("Scripting service not found. Nothing to upgrade", e);
+        } catch (SMSException | SSOException e) {
+            DEBUG.error("An error occurred while looking for missing Scripting Service configurations", e);
+            throw new UpgradeException("Unable to detect missing Scripting Service configurations", e);
+        }
+    }
+
+    private Node getGlobalConfigurationNode(Document scriptingDocument) {
+        return scriptingDocument.getElementsByTagName(SMSUtils.GLOBAL_CONFIG).item(0);
+    }
+
+    private void captureMissingSubConfigs(Node parentNode, ServiceConfig parentConfig, List<String> parentPath)
+            throws SMSException, SSOException {
+        for (Iterator it = XMLUtils.getChildNodes(parentNode, SMSUtils.SUB_CONFIG).iterator(); it.hasNext();) {
+            Node node = (Node) it.next();
+            String name = XMLUtils.getNodeAttributeValue(node, NAME);
+            ServiceConfig existingConfig = parentConfig.getSubConfig(name);
+            if (existingConfig == null) {
+                missingSubConfigs.add(new MissingSubConfig(new ArrayList<>(parentPath), name, node));
+            } else {
+                parentPath.add(name);
+                captureMissingSubConfigs(node, existingConfig, parentPath);
+                parentPath.remove(parentPath.size() - 1);
+            }
+        }
+    }
+
+    @Override
+    public boolean isApplicable() {
+        return !missingSubConfigs.isEmpty();
+    }
+
+    @Override
+    public void perform() throws UpgradeException {
+        try {
+            ServiceConfig globalConfig = getScriptingGlobalConfig();
+            for (MissingSubConfig missing : missingSubConfigs) {
+                UpgradeProgress.reportStart(AUDIT_NEW_SUB_CONFIG_START, missing.name);
+                ServiceConfig parentConfig = globalConfig;
+                for (String parentName : missing.parentPath) {
+                    parentConfig = parentConfig.getSubConfig(parentName);
+                }
+                addSubConfig(parentConfig, missing.node);
+                UpgradeProgress.reportEnd("upgrade.success");
+            }
+        } catch (SMSException | SSOException e) {
+            UpgradeProgress.reportEnd("upgrade.failed");
+            DEBUG.error("An error occurred while adding missing Scripting Service configurations", e);
+            throw new UpgradeException("Unable to add missing Scripting Service configurations", e);
+        }
+    }
+
+    private void addSubConfig(ServiceConfig parentConfig, Node node) throws SMSException, SSOException {
+        String name = XMLUtils.getNodeAttributeValue(node, NAME);
+        String id = XMLUtils.getNodeAttributeValue(node, ID);
+        if (StringUtils.isEmpty(id)) {
+            id = name;
+        }
+        String priority = XMLUtils.getNodeAttributeValue(node, PRIORITY);
+        Map<String, Set<String>> attributes = CreateServiceConfig.getAttributeValuePairs(node);
+        parentConfig.addSubConfig(name, id, priority == null ? 0 : Integer.parseInt(priority),
+                attributes == null ? Collections.<String, Set<String>>emptyMap() : attributes);
+        DEBUG.message("Created Scripting Service configuration {} with id {}", name, id);
+
+        Iterator children = XMLUtils.getChildNodes(node, SMSUtils.SUB_CONFIG).iterator();
+        if (children.hasNext()) {
+            ServiceConfig createdConfig = parentConfig.getSubConfig(name);
+            while (children.hasNext()) {
+                addSubConfig(createdConfig, (Node) children.next());
+            }
+        }
+    }
+
+    @Override
+    public String getShortReport(String delimiter) {
+        StringBuilder sb = new StringBuilder();
+        if (!missingSubConfigs.isEmpty()) {
+            sb.append(MessageFormat.format(BUNDLE.getString(AUDIT_NEW_SUB_CONFIGS), missingSubConfigs.size()));
+            sb.append(delimiter);
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String getDetailedReport(String delimiter) {
+        Map<String, String> tags = new HashMap<>();
+        tags.put(LF, delimiter);
+
+        StringBuilder sb = new StringBuilder();
+        for (MissingSubConfig missing : missingSubConfigs) {
+            sb.append(INDENT);
+            sb.append(MessageFormat.format(BUNDLE.getString(AUDIT_NEW_SUB_CONFIG), missing.getDisplayName()));
+            sb.append(delimiter);
+        }
+        tags.put("%REPORT_DATA%", sb.toString());
+        return tagSwapReport(tags, AUDIT_REPORT);
+    }
+
+    /**
+     * Get the Scripting Service definition XML with all tags swapped for their configured values.
+     * @return The Scripting Service DOM model.
+     * @throws UpgradeException When the service XML cannot be loaded.
+     */
+    protected Document getScriptingServiceXML() throws UpgradeException {
+        Document document = UpgradeServiceUtils.getServiceDefinitions(getAdminToken()).get(SCRIPTING_SERVICE_NAME);
+        if (document == null) {
+            throw new UpgradeException("Unable to find the Scripting Service definition");
+        }
+        return document;
+    }
+
+    /**
+     * Get the global configuration of the Scripting Service from the configuration data store.
+     * @return The global Scripting Service configuration.
+     * @throws SMSException When the Scripting Service is not available.
+     * @throws SSOException When the admin token is not valid.
+     */
+    protected ServiceConfig getScriptingGlobalConfig() throws SMSException, SSOException {
+        return new ServiceConfigManager(SCRIPTING_SERVICE_NAME, getAdminToken()).getGlobalConfig(null);
+    }
+
+    private static final class MissingSubConfig {
+
+        private final List<String> parentPath;
+        private final String name;
+        private final Node node;
+
+        private MissingSubConfig(List<String> parentPath, String name, Node node) {
+            this.parentPath = parentPath;
+            this.name = name;
+            this.node = node;
+        }
+
+        private String getDisplayName() {
+            StringBuilder sb = new StringBuilder();
+            for (String parentName : parentPath) {
+                sb.append(parentName).append('/');
+            }
+            return sb.append(name).toString();
+        }
+    }
+}

--- a/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/helpers/ScriptingServiceHelperTest.java
+++ b/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/helpers/ScriptingServiceHelperTest.java
@@ -1,0 +1,89 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.forgerock.openam.upgrade.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.testng.annotations.Test;
+import org.w3c.dom.Node;
+
+import com.sun.identity.shared.xml.XMLUtils;
+import com.sun.identity.sm.AttributeSchemaImpl;
+
+/**
+ * Unit test to exercise the behaviour of {@link ScriptingServiceHelper}.
+ */
+public class ScriptingServiceHelperTest {
+
+    private static final String OLD_CHOICE_VALUES =
+            "<ChoiceValues>"
+            + "<ChoiceValue i18nKey=\"script-type-01\">POLICY_CONDITION</ChoiceValue>"
+            + "<ChoiceValue i18nKey=\"script-type-02\">AUTHENTICATION_SERVER_SIDE</ChoiceValue>"
+            + "<ChoiceValue i18nKey=\"script-type-03\">AUTHENTICATION_CLIENT_SIDE</ChoiceValue>"
+            + "<ChoiceValue i18nKey=\"script-type-04\">OIDC_CLAIMS</ChoiceValue>"
+            + "</ChoiceValues>";
+    private static final String NEW_CHOICE_VALUES = OLD_CHOICE_VALUES.replace("</ChoiceValues>",
+            "<ChoiceValue i18nKey=\"script-type-05\">OAUTH2_ACCESS_TOKEN_MODIFICATION</ChoiceValue>"
+            + "</ChoiceValues>");
+
+    private final ScriptingServiceHelper helper = new ScriptingServiceHelper();
+
+    @Test
+    public void addsNewChoiceValuesPreservingConfiguredDefault() throws Exception {
+        AttributeSchemaImpl upgraded = helper.upgradeAttribute(
+                attributeSchema(OLD_CHOICE_VALUES, "OIDC_CLAIMS"),
+                attributeSchema(NEW_CHOICE_VALUES, "POLICY_CONDITION"));
+
+        assertThat(upgraded).isNotNull();
+        assertThat(upgraded.getChoiceValues()).contains("OAUTH2_ACCESS_TOKEN_MODIFICATION");
+        assertThat(upgraded.getDefaultValues()).containsExactly("OIDC_CLAIMS");
+    }
+
+    @Test
+    public void returnsNullWhenChoiceValuesAreUnchanged() throws Exception {
+        assertThat(helper.upgradeAttribute(
+                attributeSchema(NEW_CHOICE_VALUES, "OIDC_CLAIMS"),
+                attributeSchema(NEW_CHOICE_VALUES, "POLICY_CONDITION"))).isNull();
+    }
+
+    @Test
+    public void usesBundledDefaultWhenNoDefaultIsConfigured() throws Exception {
+        AttributeSchemaImpl upgraded = helper.upgradeAttribute(
+                attributeSchema(OLD_CHOICE_VALUES, null),
+                attributeSchema(NEW_CHOICE_VALUES, "POLICY_CONDITION"));
+
+        assertThat(upgraded).isNotNull();
+        assertThat(upgraded.getChoiceValues()).contains("OAUTH2_ACCESS_TOKEN_MODIFICATION");
+        assertThat(upgraded.getDefaultValues()).containsExactly("POLICY_CONDITION");
+    }
+
+    private static AttributeSchemaImpl attributeSchema(String choiceValues, String defaultValue) {
+        String xml = "<AttributeSchema name=\"defaultScriptContext\" type=\"single_choice\" syntax=\"string\">"
+                + choiceValues
+                + (defaultValue == null ? "" : "<DefaultValues><Value>" + defaultValue + "</Value></DefaultValues>")
+                + "</AttributeSchema>";
+        Node node = XMLUtils.toDOMDocument(xml, null).getDocumentElement();
+        return new TestAttributeSchemaImpl(node);
+    }
+
+    /** Grants access to the protected {@link AttributeSchemaImpl} constructor. */
+    private static final class TestAttributeSchemaImpl extends AttributeSchemaImpl {
+
+        TestAttributeSchemaImpl(Node node) {
+            super(node);
+        }
+    }
+}

--- a/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/steps/scripting/UpgradeScriptingSubConfigsStepTest.java
+++ b/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/steps/scripting/UpgradeScriptingSubConfigsStepTest.java
@@ -75,6 +75,10 @@ public class UpgradeScriptingSubConfigsStepTest {
         when(existingContextConfig.getSubConfig(ENGINE_CONFIGURATION)).thenReturn(existingEngineConfig);
         when(globalConfig.getSubConfig(GLOBAL_SCRIPTS)).thenReturn(globalScriptsConfig);
         when(globalScriptsConfig.getSubConfig(EXISTING_SCRIPT_ID)).thenReturn(existingScriptConfig);
+        when(existingContextConfig.exists()).thenReturn(true);
+        when(existingEngineConfig.exists()).thenReturn(true);
+        when(globalScriptsConfig.exists()).thenReturn(true);
+        when(existingScriptConfig.exists()).thenReturn(true);
 
         PrivilegedAction<SSOToken> adminTokenAction = mock(PrivilegedAction.class);
         ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
@@ -90,9 +94,10 @@ public class UpgradeScriptingSubConfigsStepTest {
         upgradeStep.initialize();
 
         assertThat(upgradeStep.isApplicable()).isTrue();
-        assertThat(upgradeStep.getShortReport("-")).isEqualTo("New Scripting Service configurations (2)-");
+        assertThat(upgradeStep.getShortReport("-")).isEqualTo("New Scripting Service configurations (3)-");
         assertThat(upgradeStep.getDetailedReport("-"))
                 .contains(NEW_CONTEXT)
+                .contains(NEW_CONTEXT + "/" + ENGINE_CONFIGURATION)
                 .contains(GLOBAL_SCRIPTS + "/" + NEW_SCRIPT_ID);
 
         upgradeStep.perform();
@@ -101,11 +106,12 @@ public class UpgradeScriptingSubConfigsStepTest {
         verify(globalConfig).addSubConfig(eq(NEW_CONTEXT), eq("scriptContext"), eq(0), contextAttributes.capture());
         assertThat(contextAttributes.getValue()).containsEntry("defaultScript", singleton(NEW_SCRIPT_ID));
 
+        // The service definition declares the new engine configuration as an empty element without an id,
+        // so the id falls back to the name and the attribute map is empty.
         ArgumentCaptor<Map<String, Set<String>>> engineAttributes = ArgumentCaptor.forClass(Map.class);
         verify(createdContextConfig).addSubConfig(eq(ENGINE_CONFIGURATION), eq(ENGINE_CONFIGURATION), eq(0),
                 engineAttributes.capture());
-        assertThat(engineAttributes.getValue().get("whiteList"))
-                .containsExactlyInAnyOrder("java.lang.Boolean", "java.lang.String");
+        assertThat(engineAttributes.getValue()).isEmpty();
 
         ArgumentCaptor<Map<String, Set<String>>> scriptAttributes = ArgumentCaptor.forClass(Map.class);
         verify(globalScriptsConfig).addSubConfig(eq(NEW_SCRIPT_ID), eq("globalScript"), eq(0),
@@ -120,11 +126,33 @@ public class UpgradeScriptingSubConfigsStepTest {
     }
 
     @Test
+    public void addsEngineConfigurationWhenContextExistsWithoutIt() throws Exception {
+        // For an absent entry whose name matches its sub-schema name (engineConfiguration), getSubConfig
+        // returns a non-null config wrapping a non-existent SMSEntry instead of null, e.g. after a manual
+        // ssoadm workaround created the context but not its engine configuration.
+        when(existingEngineConfig.exists()).thenReturn(false);
+        stubNewContextAndScriptAsExisting();
+
+        upgradeStep.initialize();
+
+        assertThat(upgradeStep.isApplicable()).isTrue();
+        assertThat(upgradeStep.getShortReport("-")).isEqualTo("New Scripting Service configurations (1)-");
+        assertThat(upgradeStep.getDetailedReport("-")).contains(EXISTING_CONTEXT + "/" + ENGINE_CONFIGURATION);
+
+        upgradeStep.perform();
+
+        ArgumentCaptor<Map<String, Set<String>>> engineAttributes = ArgumentCaptor.forClass(Map.class);
+        verify(existingContextConfig).addSubConfig(eq(ENGINE_CONFIGURATION), eq(ENGINE_CONFIGURATION), eq(0),
+                engineAttributes.capture());
+        assertThat(engineAttributes.getValue()).containsEntry("whiteList", singleton("java.lang.String"));
+
+        verify(globalConfig, never()).addSubConfig(anyString(), anyString(), anyInt(), any(Map.class));
+        verify(globalScriptsConfig, never()).addSubConfig(anyString(), anyString(), anyInt(), any(Map.class));
+    }
+
+    @Test
     public void doesNothingWhenAllSubConfigsExist() throws Exception {
-        ServiceConfig newContextConfig = mock(ServiceConfig.class);
-        when(globalConfig.getSubConfig(NEW_CONTEXT)).thenReturn(newContextConfig);
-        when(newContextConfig.getSubConfig(ENGINE_CONFIGURATION)).thenReturn(mock(ServiceConfig.class));
-        when(globalScriptsConfig.getSubConfig(NEW_SCRIPT_ID)).thenReturn(mock(ServiceConfig.class));
+        ServiceConfig newContextConfig = stubNewContextAndScriptAsExisting();
 
         upgradeStep.initialize();
 
@@ -136,6 +164,19 @@ public class UpgradeScriptingSubConfigsStepTest {
         verify(globalConfig, never()).addSubConfig(anyString(), anyString(), anyInt(), any(Map.class));
         verify(globalScriptsConfig, never()).addSubConfig(anyString(), anyString(), anyInt(), any(Map.class));
         verify(newContextConfig, never()).addSubConfig(anyString(), anyString(), anyInt(), any(Map.class));
+    }
+
+    private ServiceConfig stubNewContextAndScriptAsExisting() throws Exception {
+        ServiceConfig newContextConfig = mock(ServiceConfig.class);
+        ServiceConfig newEngineConfig = mock(ServiceConfig.class);
+        ServiceConfig newScriptConfig = mock(ServiceConfig.class);
+        when(globalConfig.getSubConfig(NEW_CONTEXT)).thenReturn(newContextConfig);
+        when(newContextConfig.getSubConfig(ENGINE_CONFIGURATION)).thenReturn(newEngineConfig);
+        when(globalScriptsConfig.getSubConfig(NEW_SCRIPT_ID)).thenReturn(newScriptConfig);
+        when(newContextConfig.exists()).thenReturn(true);
+        when(newEngineConfig.exists()).thenReturn(true);
+        when(newScriptConfig.exists()).thenReturn(true);
+        return newContextConfig;
     }
 
     /**

--- a/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/steps/scripting/UpgradeScriptingSubConfigsStepTest.java
+++ b/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/steps/scripting/UpgradeScriptingSubConfigsStepTest.java
@@ -1,0 +1,166 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.forgerock.openam.upgrade.steps.scripting;
+
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.security.PrivilegedAction;
+import java.util.Map;
+import java.util.Set;
+
+import org.forgerock.openam.sm.datalayer.api.ConnectionFactory;
+import org.forgerock.openam.upgrade.UpgradeException;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.w3c.dom.Document;
+
+import com.iplanet.sso.SSOToken;
+import com.sun.identity.shared.xml.XMLUtils;
+import com.sun.identity.sm.ServiceConfig;
+
+/**
+ * Unit test to exercise the behaviour of {@link UpgradeScriptingSubConfigsStep}.
+ */
+public class UpgradeScriptingSubConfigsStepTest {
+
+    private static final String EXISTING_CONTEXT = "OIDC_CLAIMS";
+    private static final String EXISTING_SCRIPT_ID = "36863ffb-40ec-48b9-94b1-9a99f71cc3b5";
+    private static final String NEW_CONTEXT = "OAUTH2_ACCESS_TOKEN_MODIFICATION";
+    private static final String NEW_SCRIPT_ID = "d22f9a0c-426a-4466-b95e-d0f125b0d5fa";
+    private static final String GLOBAL_SCRIPTS = "globalScripts";
+    private static final String ENGINE_CONFIGURATION = "engineConfiguration";
+
+    private UpgradeScriptingSubConfigsStep upgradeStep;
+
+    private ServiceConfig globalConfig;
+    private ServiceConfig existingContextConfig;
+    private ServiceConfig existingEngineConfig;
+    private ServiceConfig globalScriptsConfig;
+    private ServiceConfig existingScriptConfig;
+    private ServiceConfig createdContextConfig;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        globalConfig = mock(ServiceConfig.class);
+        existingContextConfig = mock(ServiceConfig.class);
+        existingEngineConfig = mock(ServiceConfig.class);
+        globalScriptsConfig = mock(ServiceConfig.class);
+        existingScriptConfig = mock(ServiceConfig.class);
+        createdContextConfig = mock(ServiceConfig.class);
+
+        when(globalConfig.getSubConfig(EXISTING_CONTEXT)).thenReturn(existingContextConfig);
+        when(existingContextConfig.getSubConfig(ENGINE_CONFIGURATION)).thenReturn(existingEngineConfig);
+        when(globalConfig.getSubConfig(GLOBAL_SCRIPTS)).thenReturn(globalScriptsConfig);
+        when(globalScriptsConfig.getSubConfig(EXISTING_SCRIPT_ID)).thenReturn(existingScriptConfig);
+
+        PrivilegedAction<SSOToken> adminTokenAction = mock(PrivilegedAction.class);
+        ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+        upgradeStep = new SafeUpgradeScriptingSubConfigsStep(adminTokenAction, connectionFactory);
+    }
+
+    @Test
+    public void addsMissingContextAndGlobalScript() throws Exception {
+        // The new script context and its default global script do not exist yet; the context is only
+        // resolvable after it has been created.
+        when(globalConfig.getSubConfig(NEW_CONTEXT)).thenReturn(null, createdContextConfig);
+
+        upgradeStep.initialize();
+
+        assertThat(upgradeStep.isApplicable()).isTrue();
+        assertThat(upgradeStep.getShortReport("-")).isEqualTo("New Scripting Service configurations (2)-");
+        assertThat(upgradeStep.getDetailedReport("-"))
+                .contains(NEW_CONTEXT)
+                .contains(GLOBAL_SCRIPTS + "/" + NEW_SCRIPT_ID);
+
+        upgradeStep.perform();
+
+        ArgumentCaptor<Map<String, Set<String>>> contextAttributes = ArgumentCaptor.forClass(Map.class);
+        verify(globalConfig).addSubConfig(eq(NEW_CONTEXT), eq("scriptContext"), eq(0), contextAttributes.capture());
+        assertThat(contextAttributes.getValue()).containsEntry("defaultScript", singleton(NEW_SCRIPT_ID));
+
+        ArgumentCaptor<Map<String, Set<String>>> engineAttributes = ArgumentCaptor.forClass(Map.class);
+        verify(createdContextConfig).addSubConfig(eq(ENGINE_CONFIGURATION), eq(ENGINE_CONFIGURATION), eq(0),
+                engineAttributes.capture());
+        assertThat(engineAttributes.getValue().get("whiteList"))
+                .containsExactlyInAnyOrder("java.lang.Boolean", "java.lang.String");
+
+        ArgumentCaptor<Map<String, Set<String>>> scriptAttributes = ArgumentCaptor.forClass(Map.class);
+        verify(globalScriptsConfig).addSubConfig(eq(NEW_SCRIPT_ID), eq("globalScript"), eq(0),
+                scriptAttributes.capture());
+        assertThat(scriptAttributes.getValue())
+                .containsEntry("name", singleton("OAuth2 Access Token Modification Script"))
+                .containsEntry("context", singleton(NEW_CONTEXT))
+                .containsEntry("language", singleton("GROOVY"))
+                .containsEntry("script", singleton("// access token modification script"));
+
+        verify(existingContextConfig, never()).addSubConfig(anyString(), anyString(), anyInt(), any(Map.class));
+    }
+
+    @Test
+    public void doesNothingWhenAllSubConfigsExist() throws Exception {
+        ServiceConfig newContextConfig = mock(ServiceConfig.class);
+        when(globalConfig.getSubConfig(NEW_CONTEXT)).thenReturn(newContextConfig);
+        when(newContextConfig.getSubConfig(ENGINE_CONFIGURATION)).thenReturn(mock(ServiceConfig.class));
+        when(globalScriptsConfig.getSubConfig(NEW_SCRIPT_ID)).thenReturn(mock(ServiceConfig.class));
+
+        upgradeStep.initialize();
+
+        assertThat(upgradeStep.isApplicable()).isFalse();
+        assertThat(upgradeStep.getShortReport("-")).isEmpty();
+
+        upgradeStep.perform();
+
+        verify(globalConfig, never()).addSubConfig(anyString(), anyString(), anyInt(), any(Map.class));
+        verify(globalScriptsConfig, never()).addSubConfig(anyString(), anyString(), anyInt(), any(Map.class));
+        verify(newContextConfig, never()).addSubConfig(anyString(), anyString(), anyInt(), any(Map.class));
+    }
+
+    /**
+     * Test class with the data store and service definition access mocked out, so to work against the test
+     * xml and the mocked global configuration instead.
+     */
+    private final class SafeUpgradeScriptingSubConfigsStep extends UpgradeScriptingSubConfigsStep {
+
+        SafeUpgradeScriptingSubConfigsStep(PrivilegedAction<SSOToken> adminTokenAction,
+                ConnectionFactory connectionFactory) {
+            super(adminTokenAction, connectionFactory);
+        }
+
+        @Override
+        protected Document getScriptingServiceXML() throws UpgradeException {
+            try {
+                return XMLUtils.getXMLDocument(ClassLoader.getSystemResourceAsStream("test-scripting.xml"));
+            } catch (Exception e) {
+                throw new UpgradeException(e);
+            }
+        }
+
+        @Override
+        protected ServiceConfig getScriptingGlobalConfig() {
+            return globalConfig;
+        }
+    }
+}

--- a/openam-upgrade/src/test/resources/test-scripting.xml
+++ b/openam-upgrade/src/test/resources/test-scripting.xml
@@ -35,13 +35,7 @@
                         <Attribute name="defaultScript"/>
                         <Value>d22f9a0c-426a-4466-b95e-d0f125b0d5fa</Value>
                     </AttributeValuePair>
-                    <SubConfiguration name="engineConfiguration" id="engineConfiguration">
-                        <AttributeValuePair>
-                            <Attribute name="whiteList"/>
-                            <Value>java.lang.Boolean</Value>
-                            <Value>java.lang.String</Value>
-                        </AttributeValuePair>
-                    </SubConfiguration>
+                    <SubConfiguration name="engineConfiguration"/>
                 </SubConfiguration>
                 <SubConfiguration name="globalScripts" id="globalScripts">
                     <SubConfiguration name="36863ffb-40ec-48b9-94b1-9a99f71cc3b5" id="globalScript">

--- a/openam-upgrade/src/test/resources/test-scripting.xml
+++ b/openam-upgrade/src/test/resources/test-scripting.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The contents of this file are subject to the terms of the Common Development and
+  Distribution License (the License). You may not use this file except in compliance with the
+  License.
+
+  You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+  specific language governing permission and limitations under the License.
+
+  When distributing Covered Software, include this CDDL Header Notice in each file and include
+  the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+  Header, with the fields enclosed by brackets [] replaced by your own identifying
+  information: "Portions copyright [year] [name of copyright owner]".
+
+  Copyright 2026 3A Systems, LLC.
+-->
+<ServicesConfiguration>
+    <Service name="ScriptingService" version="1.0">
+        <Configuration>
+            <GlobalConfiguration>
+                <SubConfiguration name="OIDC_CLAIMS" id="scriptContext">
+                    <AttributeValuePair>
+                        <Attribute name="defaultScript"/>
+                        <Value>36863ffb-40ec-48b9-94b1-9a99f71cc3b5</Value>
+                    </AttributeValuePair>
+                    <SubConfiguration name="engineConfiguration" id="engineConfiguration">
+                        <AttributeValuePair>
+                            <Attribute name="whiteList"/>
+                            <Value>java.lang.String</Value>
+                        </AttributeValuePair>
+                    </SubConfiguration>
+                </SubConfiguration>
+                <SubConfiguration name="OAUTH2_ACCESS_TOKEN_MODIFICATION" id="scriptContext">
+                    <AttributeValuePair>
+                        <Attribute name="defaultScript"/>
+                        <Value>d22f9a0c-426a-4466-b95e-d0f125b0d5fa</Value>
+                    </AttributeValuePair>
+                    <SubConfiguration name="engineConfiguration" id="engineConfiguration">
+                        <AttributeValuePair>
+                            <Attribute name="whiteList"/>
+                            <Value>java.lang.Boolean</Value>
+                            <Value>java.lang.String</Value>
+                        </AttributeValuePair>
+                    </SubConfiguration>
+                </SubConfiguration>
+                <SubConfiguration name="globalScripts" id="globalScripts">
+                    <SubConfiguration name="36863ffb-40ec-48b9-94b1-9a99f71cc3b5" id="globalScript">
+                        <AttributeValuePair>
+                            <Attribute name="name"/>
+                            <Value>OIDC Claims Script</Value>
+                        </AttributeValuePair>
+                        <AttributeValuePair>
+                            <Attribute name="context"/>
+                            <Value>OIDC_CLAIMS</Value>
+                        </AttributeValuePair>
+                        <AttributeValuePair>
+                            <Attribute name="language"/>
+                            <Value>GROOVY</Value>
+                        </AttributeValuePair>
+                        <AttributeValuePair>
+                            <Attribute name="script"/>
+                            <Value>// OIDC claims script</Value>
+                        </AttributeValuePair>
+                    </SubConfiguration>
+                    <SubConfiguration name="d22f9a0c-426a-4466-b95e-d0f125b0d5fa" id="globalScript">
+                        <AttributeValuePair>
+                            <Attribute name="name"/>
+                            <Value>OAuth2 Access Token Modification Script</Value>
+                        </AttributeValuePair>
+                        <AttributeValuePair>
+                            <Attribute name="description"/>
+                            <Value>Default global script for OAuth2 Access Token Modification</Value>
+                        </AttributeValuePair>
+                        <AttributeValuePair>
+                            <Attribute name="context"/>
+                            <Value>OAUTH2_ACCESS_TOKEN_MODIFICATION</Value>
+                        </AttributeValuePair>
+                        <AttributeValuePair>
+                            <Attribute name="language"/>
+                            <Value>GROOVY</Value>
+                        </AttributeValuePair>
+                        <AttributeValuePair>
+                            <Attribute name="script"/>
+                            <Value>// access token modification script</Value>
+                        </AttributeValuePair>
+                    </SubConfiguration>
+                </SubConfiguration>
+            </GlobalConfiguration>
+        </Configuration>
+    </Service>
+</ServicesConfiguration>


### PR DESCRIPTION
## Summary

Fixes #1103.

PR #1034 (16.1.1) introduced the `OAUTH2_ACCESS_TOKEN_MODIFICATION` script context and its default global script in the `<Configuration>` section of `scripting.xml`. The SMS only registers that section when the whole service is new, and the upgrade framework (`UpgradeServiceSchemaStep` → `ServiceSchemaModifications`) diffs `<Schema>` only. As a result, instances upgraded from a version that already contained the Scripting Service (e.g. 16.0.6 → 16.1.1) are left without:

- the `scriptContext=OAUTH2_ACCESS_TOKEN_MODIFICATION` sub-configuration (incl. its `engineConfiguration` whitelist),
- the `globalScripts/d22f9a0c-426a-4466-b95e-d0f125b0d5fa` default global script,
- the new context choice values in the `ScriptingService` schema (attribute *modifications* are only applied when an `UpgradeHelper` is registered for the service, and `ScriptingService` had none).

Meanwhile the new OAuth2 Provider attribute `forgerock-oauth2-provider-access-token-modification-script` **is** added on upgrade (via `OAuth2ProviderUpgradeHelper`) with its default pointing at the missing script. Reading `/json/global-config/services?_action=nextdescendents` then fails `single_choice` validation (`ScriptChoiceValues` finds no script of that context) and the whole Global Services page returns 500.

## Changes

- **`UpgradeScriptingSubConfigsStep`** (new, depends on `UpgradeServiceSchemaStep`): reads the tag-swapped bundled `scripting.xml` via `UpgradeServiceUtils.getServiceDefinitions`, navigates to `Service[@name='ScriptingService']/Configuration/GlobalConfiguration`, recursively compares its sub-configurations with the Scripting Service global config in the data store, and creates any missing ones. Presence is determined via `SMSUtils.serviceExists`, not a null check — for an absent entry whose name matches its sub-schema name (`engineConfiguration`, `globalScripts`) `ServiceConfig.getSubConfig` returns a non-null config wrapping a non-existent `SMSEntry`, so a partially applied manual workaround (e.g. `ssoadm create-sub-cfg` for the context without its engine configuration) is also healed. Entries under `globalScripts` are created before the script contexts that reference them via `defaultScript`, so a failure part-way through cannot leave the store in the broken #1103 shape. `perform()` guards against missing parents, re-checks existence before creating (the missing list is captured in `initialize()`), and reports failure on unchecked exceptions too; `initialize()` wraps unexpected exceptions into a descriptive `UpgradeException` instead of aborting the whole upgrade with a bare NPE. The upgrade report counts and lists all created sub-configurations, including descendants of the missing nodes. Existing sub-configurations are left untouched (user-tuned engine whitelists are not overwritten). The generic diff also self-heals installations already upgraded to 16.1.1/16.1.2 on their next upgrade, and automatically covers any script contexts added in future versions. Follows the `UpgradeEntitlementSubConfigsStep` pattern.
- **`ScriptingServiceHelper`** (new, registered in `serverupgrade.properties`): syncs the script context choice values of the global `defaultScriptContext` attribute *and* the realm-level `scriptConfiguration.context` attribute with the service definition. The comparison reads the raw `<ChoiceValues>` of the schema nodes, because `AttributeSchemaImpl` does not parse them for the `type="single"` attribute `scriptConfiguration.context` — a `getChoiceValues()`-based comparison could never detect that change. The administrator's configured default is preserved (for Global attributes the configured value is persisted as the schema default, so it is grafted onto the new node via `updateDefaultValues`, same pattern as `LoggingUpgradeHelper`) — unless it is no longer a valid choice, in which case the bundled default is restored to avoid re-creating the very `single_choice` 500 this PR fixes.
- `UpgradeServiceUtils.getServiceDefinitions` widened to `public` so the step in the `steps.scripting` sub-package can reuse it.
- New report keys in `amUpgrade.properties`.
- Removed two dead lines from `serverupgrade.properties` (an orphaned `RestSecurity=...UserSelfServiceHelper` entry outside the `upgrade.helper` continuation, referencing a class that no longer exists, and a duplicate `services.to.delete` key).

Creation order is safe: the `defaultScript` attribute of `scriptContext` validates against the `ScriptConstants.GlobalScript` enum (`GlobalOnly=true`), not against the data store.

Known limitations (documented in the step javadoc): attributes of existing sub-configurations are never reconciled with the service definition, and a missing single-instance sub-configuration (such as the whole `globalScripts` node) cannot be created under a parent that already has other children — unreachable on supported upgrade paths, since all such nodes have existed since OpenAM 13.

## Testing

```
mvn -o -pl openam-upgrade test
# Tests run: 136, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

- `UpgradeScriptingSubConfigsStepTest` (+ `test-scripting.xml` resource, mirroring the real service definition) verifies that the missing script context and default global script are created with the expected attributes in the right order (script before the context that references it), that the engine configuration whitelist — including `org.forgerock.openam.oauth2.ScriptableAccessToken` — is carried through, and that a phantom `engineConfiguration` under an existing context (non-null `getSubConfig` result with `exists() == false`) is detected and created. The `id = name` and empty-attribute fallbacks are exercised by a clearly marked synthetic fixture node. Also covered: the perform-time skip of an entry created after `initialize()`, a parent disappearing before `perform()`, both `initialize()` early exits, and the not-applicable case when everything is already configured.
- `ScriptingServiceHelperTest` verifies that new choice values are added while the administrator's configured default is preserved, that the bundled default is used when none is configured or the configured one is no longer a valid choice, that the `type="single"` realm context attribute is synced via the raw schema nodes, and that unchanged choice values produce no modification.
- The generated `upgradesteps.properties` orders the new step after `UpgradeServiceSchemaStep` and `ScriptingSchemaStep`.
