### PR TITLE
[#1111] Click fork: stop calling javax.servlet-bound upstream ClickUtils

### DIFF
--- a/openam-core/src/main/java/org/openidentityplatform/openam/click/util/ClickUtils.java
+++ b/openam-core/src/main/java/org/openidentityplatform/openam/click/util/ClickUtils.java
@@ -534,11 +534,11 @@ public class ClickUtils {
             }
 
         } catch (IOException ex) {
-            org.apache.click.util.ClickUtils.getLogService().error(ex.getMessage(), ex);
+            getLogService().error(ex.getMessage(), ex);
 
         } finally {
-            org.apache.click.util.ClickUtils.close(gos);
-            org.apache.click.util.ClickUtils.close(os);
+            close(gos);
+            close(os);
         }
     }
 
@@ -1151,7 +1151,7 @@ public class ClickUtils {
                 servletContext.getResourceAsStream(DEFAULT_APP_CONFIG);
 
         if (inputStream == null) {
-            inputStream = org.apache.click.util.ClickUtils.getResourceAsStream("/click.xml", org.apache.click.util.ClickUtils.class);
+            inputStream = getResourceAsStream("/click.xml", ClickUtils.class);
             if (inputStream == null) {
                 String msg =
                         "could not find click app configuration file: "
@@ -1570,7 +1570,7 @@ public class ClickUtils {
 
             if (!destinationFile.exists()) {
                 InputStream inputStream =
-                        getResourceAsStream(resource, org.apache.click.util.ClickUtils.class);
+                        getResourceAsStream(resource, ClickUtils.class);
 
                 if (inputStream != null) {
                     FileOutputStream fos = null;
@@ -1676,7 +1676,7 @@ public class ClickUtils {
         String descriptorFile = packageName + "/" + controlName + ".files";
         logService.debug("Use deployment descriptor file:" + descriptorFile);
 
-        InputStream is = getResourceAsStream(descriptorFile, org.apache.click.util.ClickUtils.class);
+        InputStream is = getResourceAsStream(descriptorFile, ClickUtils.class);
         List fileList = IOUtils.readLines(is);
         if (fileList == null || fileList.isEmpty()) {
             logService.info("there are no files to deploy for control " + controlClass.getName());

--- a/openam-core/src/main/java/org/openidentityplatform/openam/click/util/ClickUtils.java
+++ b/openam-core/src/main/java/org/openidentityplatform/openam/click/util/ClickUtils.java
@@ -65,7 +65,7 @@ import org.openidentityplatform.openam.click.ActionResult;
 import org.apache.click.Stateful;
 import org.openidentityplatform.openam.click.control.AbstractControl;
 import org.openidentityplatform.openam.click.control.AbstractLink;
-import org.apache.click.control.ActionLink;
+import org.openidentityplatform.openam.click.control.ActionLink;
 import org.openidentityplatform.openam.click.control.Container;
 import org.openidentityplatform.openam.click.control.Field;
 import org.openidentityplatform.openam.click.control.Form;
@@ -1187,7 +1187,7 @@ public class ClickUtils {
                             + " editing your web.xml and setting the load-on-startup to 0:\n\n"
                             + " <servlet>\n"
                             + "   <servlet-name>ClickServlet</servlet-name>\n"
-                            + "   <servlet-class>org.apache.click.ClickServlet</servlet-class>\n"
+                            + "   <servlet-class>org.openidentityplatform.openam.click.ClickServlet</servlet-class>\n"
                             + "   <load-on-startup>0</load-on-startup>\n"
                             + " </servlet>\n";
 
@@ -1410,7 +1410,7 @@ public class ClickUtils {
      *
      *   <li>if control.getName() is set do the following:
      *     <ol>
-     *       <li>if the control is of type {@link org.apache.click.control.ActionLink},
+     *       <li>if the control is of type {@link org.openidentityplatform.openam.click.control.ActionLink},
      *       it's "<code>class</code>" attribute selector will be returned. For example:
      *       <code>a[class=red]</code>. <b>Please note:</b> if the link class attribute is
      *       not set, the class attribute will be set to its name, prefixed with
@@ -2194,8 +2194,8 @@ public class ClickUtils {
 
     /**
      * Return the list of Fields for the given Form, including any Fields
-     * contained in FieldSets. The list of returned fields will exclude any
-     * <code>Button</code>, <code>FieldSet</code> or <code>Label</code> fields.
+     * contained in child containers. The list of returned fields will exclude
+     * any <code>Button</code> or <code>Label</code> fields.
      *
      * @param form the form to obtain the fields from
      * @return the list of contained form fields
@@ -3072,7 +3072,7 @@ public class ClickUtils {
         for (int i = 0; i < container.getControls().size(); i++) {
             Control control = container.getControls().get(i);
             if (control instanceof Container) {
-                // Include fields but skip fieldSets
+                // Include fields that are containers
                 if (control instanceof Field) {
                     Field field = (Field) control;
                     bindField(field, context);

--- a/openam-core/src/main/java/org/openidentityplatform/openam/click/util/ContainerUtils.java
+++ b/openam-core/src/main/java/org/openidentityplatform/openam/click/util/ContainerUtils.java
@@ -43,8 +43,7 @@ import org.openidentityplatform.openam.click.control.Field;
 import org.apache.click.control.FieldSet;
 import org.openidentityplatform.openam.click.control.Form;
 import org.apache.click.control.Label;
-import org.apache.click.service.LogService;
-import org.apache.click.util.ClickUtils;
+import org.openidentityplatform.openam.click.service.LogService;
 import org.apache.click.util.HtmlStringBuffer;
 import org.apache.click.util.PropertyUtils;
 import org.apache.commons.lang.ClassUtils;
@@ -114,7 +113,7 @@ public class ContainerUtils {
         }
 
         if (fieldList.isEmpty()) {
-            LogService logService = org.apache.click.util.ClickUtils.getLogService();
+            LogService logService = ClickUtils.getLogService();
             if (logService.isDebugEnabled()) {
                 String containerClassName =
                         ClassUtils.getShortClassName(container.getClass());
@@ -137,7 +136,7 @@ public class ContainerUtils {
             return;
         }
 
-        LogService logService = org.apache.click.util.ClickUtils.getLogService();
+        LogService logService = ClickUtils.getLogService();
 
         Set<String> properties = getObjectPropertyNames(object);
         Map<?, ?> ognlContext = Ognl.createDefaultContext(
@@ -235,7 +234,7 @@ public class ContainerUtils {
         }
 
         if (fieldList.isEmpty()) {
-            LogService logService = org.apache.click.util.ClickUtils.getLogService();
+            LogService logService = ClickUtils.getLogService();
             if (logService.isDebugEnabled()) {
                 String containerClassName =
                         ClassUtils.getShortClassName(container.getClass());
@@ -261,7 +260,7 @@ public class ContainerUtils {
 
         Set<String> properties = getObjectPropertyNames(object);
 
-        LogService logService = org.apache.click.util.ClickUtils.getLogService();
+        LogService logService = ClickUtils.getLogService();
 
         for (Field field : fieldList) {
 
@@ -902,7 +901,7 @@ public class ContainerUtils {
                                      String path) {
 
         // Find the getter for property
-        String getterName = org.apache.click.util.ClickUtils.toGetterName(property);
+        String getterName = ClickUtils.toGetterName(property);
 
         Method method = null;
         Class<?> sourceClass = object.getClass();
@@ -913,7 +912,7 @@ public class ContainerUtils {
         }
 
         if (method == null) {
-            String isGetterName = org.apache.click.util.ClickUtils.toIsGetterName(property);
+            String isGetterName = ClickUtils.toIsGetterName(property);
             try {
                 method = sourceClass.getMethod(isGetterName, (Class[]) null);
             } catch (Exception e) {
@@ -973,7 +972,7 @@ public class ContainerUtils {
         Method method = null;
 
         // Find the setter for property
-        String setterName = org.apache.click.util.ClickUtils.toSetterName(property);
+        String setterName = ClickUtils.toSetterName(property);
 
         Class<?> sourceClass = source.getClass();
         Class<?>[] classArgs = { targetClass };
@@ -1050,7 +1049,7 @@ public class ContainerUtils {
      */
     private static void copyFieldsToMap(List<Field> fieldList, Map<String, Object> map) {
 
-        LogService logService = org.apache.click.util.ClickUtils.getLogService();
+        LogService logService = ClickUtils.getLogService();
 
         String objectClassname = map.getClass().getName();
         objectClassname =
@@ -1086,7 +1085,7 @@ public class ContainerUtils {
      */
     private static void copyMapToFields(Map<String, Object> map, List<Field> fieldList) {
 
-        LogService logService = org.apache.click.util.ClickUtils.getLogService();
+        LogService logService = ClickUtils.getLogService();
 
         String objectClassname = map.getClass().getName();
         objectClassname =

--- a/openam-core/src/main/java/org/openidentityplatform/openam/click/util/ContainerUtils.java
+++ b/openam-core/src/main/java/org/openidentityplatform/openam/click/util/ContainerUtils.java
@@ -37,12 +37,11 @@ import ognl.OgnlOps;
 
 import org.openidentityplatform.openam.click.Control;
 import org.openidentityplatform.openam.click.Page;
-import org.apache.click.control.Button;
+import org.openidentityplatform.openam.click.control.Button;
 import org.openidentityplatform.openam.click.control.Container;
 import org.openidentityplatform.openam.click.control.Field;
-import org.apache.click.control.FieldSet;
 import org.openidentityplatform.openam.click.control.Form;
-import org.apache.click.control.Label;
+import org.openidentityplatform.openam.click.control.Label;
 import org.openidentityplatform.openam.click.service.LogService;
 import org.apache.click.util.HtmlStringBuffer;
 import org.apache.click.util.PropertyUtils;
@@ -433,7 +432,7 @@ public class ContainerUtils {
     /**
      * Return the list of Fields for the given Container, recursively including
      * any Fields contained in child containers. The list of returned fields
-     * will exclude any <code>Button</code> and <code>FieldSet</code> fields.
+     * will exclude any <code>Button</code> fields.
      *
      * @param container the container to obtain the fields from
      * @return the list of contained fields
@@ -451,7 +450,7 @@ public class ContainerUtils {
     /**
      * Return the list of hidden Fields for the given Container, recursively including
      * any Fields contained in child containers. The list of returned fields
-     * will exclude any <code>Button</code>, <code>FieldSet</code> and <code>Label</code>
+     * will exclude any <code>Button</code> and <code>Label</code>
      * fields.
      *
      * @param container the container to obtain the fields from
@@ -471,7 +470,7 @@ public class ContainerUtils {
      * Return the list of input Fields (TextField, Select, Radio, Checkbox etc).
      * for the given Container, recursively including any Fields contained in
      * child containers. The list of returned fields will exclude any
-     * <code>Button</code>, <code>FieldSet</code> and <code>Label</code> fields.
+     * <code>Button</code> and <code>Label</code> fields.
      *
      * @param container the container to obtain the fields from
      * @return the list of contained fields
@@ -1166,7 +1165,7 @@ public class ContainerUtils {
      * Add input fields (TextField, TextArea, Select, Radio, Checkbox etc.) for
      * the given Container to the specified field list, recursively including
      * any Fields contained in child containers. The list of returned fields
-     * will exclude any <code>Button</code>, <code>FieldSet</code> and <code>Label</code>
+     * will exclude any <code>Button</code> and <code>Label</code>
      * fields.
      *
      * @param container the container to obtain the fields from
@@ -1180,8 +1179,8 @@ public class ContainerUtils {
                 continue;
 
             } else if (control instanceof Container) {
-                // Include fields but skip fieldSets
-                if (control instanceof Field && !(control instanceof FieldSet)) {
+                // Include fields that are containers
+                if (control instanceof Field) {
                     fields.add((Field) control);
                 }
                 Container childContainer = (Container) control;
@@ -1196,8 +1195,8 @@ public class ContainerUtils {
     /**
      * Add hidden fields for the given Container to the specified field list,
      * recursively including any Fields contained in child containers. The list
-     * of returned fields will exclude any <code>Button</code>, <code>FieldSet</code>
-     * and <code>Label</code> fields.
+     * of returned fields will exclude any <code>Button</code> and
+     * <code>Label</code> fields.
      *
      * @param container the container to obtain the hidden fields from
      * @param fields the list of contained fields
@@ -1210,8 +1209,8 @@ public class ContainerUtils {
                 continue;
 
             } else if (control instanceof Container) {
-                // Include fields but skip fieldSets
-                if (control instanceof Field && !(control instanceof FieldSet)) {
+                // Include fields that are containers
+                if (control instanceof Field) {
                     Field field = (Field) control;
                     if (field.isHidden()) {
                         fields.add((Field) control);
@@ -1233,7 +1232,7 @@ public class ContainerUtils {
     /**
      * Add fields for the container to the specified field list, recursively
      * including any Fields contained in child containers. The list
-     * of returned fields will exclude any <code>Button</code> and <code>FieldSet</code>
+     * of returned fields will exclude any <code>Button</code>
      * fields.
      *
      * @param container the container to obtain the fields from
@@ -1247,8 +1246,8 @@ public class ContainerUtils {
                 continue;
 
             } else if (control instanceof Container) {
-                // Include fields but skip fieldSets
-                if (control instanceof Field && !(control instanceof FieldSet)) {
+                // Include fields that are containers
+                if (control instanceof Field) {
                     fields.add((Field) control);
                 }
                 Container childContainer = (Container) control;

--- a/openam-core/src/main/java/org/openidentityplatform/openam/click/util/ErrorReport.java
+++ b/openam-core/src/main/java/org/openidentityplatform/openam/click/util/ErrorReport.java
@@ -198,7 +198,7 @@ public class ErrorReport {
 
         if (isProductionMode()) {
             Locale locale = request.getLocale();
-            ResourceBundle bundle = org.apache.click.util.ClickUtils.getBundle("click-control", locale);
+            ResourceBundle bundle = ClickUtils.getBundle("click-control", locale);
             return bundle.getString("production-error-message");
         }
 
@@ -424,7 +424,7 @@ public class ErrorReport {
                 parseMsg = message.substring(startIndex + 1, endIndex);
             }
 
-            parseMsg = org.apache.click.util.ClickUtils.escapeHtml(parseMsg);
+            parseMsg = ClickUtils.escapeHtml(parseMsg);
 
             parseMsg = StringUtils.replace(parseMsg, "...", ", &#160;");
 
@@ -436,7 +436,7 @@ public class ErrorReport {
             String value =
                     (cause.getMessage() != null) ? cause.getMessage() : "null";
 
-            return org.apache.click.util.ClickUtils.escapeHtml(value);
+            return ClickUtils.escapeHtml(value);
         }
     }
 
@@ -590,7 +590,7 @@ public class ErrorReport {
 
                 } else {
                     if (isParseError()) {
-                        buffer.append(org.apache.click.util.ClickUtils.escapeHtml(line));
+                        buffer.append(ClickUtils.escapeHtml(line));
                     } else {
                         buffer.append(getRenderJavaLine(line));
                     }
@@ -604,7 +604,7 @@ public class ErrorReport {
 
         } catch (IOException ioe) {
             buffer.append("Could not load page source: ");
-            buffer.append(org.apache.click.util.ClickUtils.escapeHtml(ioe.toString()));
+            buffer.append(ClickUtils.escapeHtml(ioe.toString()));
         } finally {
             try {
                 sourceReader.close();
@@ -632,7 +632,7 @@ public class ErrorReport {
         HtmlStringBuffer buffer
                 = new HtmlStringBuffer(sw.toString().length() + 80);
         buffer.append("<pre><tt style='font-size:10pt;'>");
-        buffer.append(org.apache.click.util.ClickUtils.escapeHtml(sw.toString().trim()));
+        buffer.append(ClickUtils.escapeHtml(sw.toString().trim()));
         buffer.append("</tt></pre>");
 
         return buffer.toString();
@@ -653,7 +653,7 @@ public class ErrorReport {
             buffer.append(key);
             buffer.append("=");
             if (value != null) {
-                buffer.append(org.apache.click.util.ClickUtils.escapeHtml(value.toString()));
+                buffer.append(ClickUtils.escapeHtml(value.toString()));
             } else {
                 buffer.append("null");
             }


### PR DESCRIPTION
The fork is compiled against jakarta.servlet, but click-nodeps 2.3.0 is not: upstream ClickUtils.getLogService() resolves a javax.servlet.Servlet- Context that is absent from the classpath, and reads a thread local that only the upstream servlet populates. Route these calls to the fork's own ClickUtils.getLogService() instead.

ContainerUtils imported org.apache.click.util.ClickUtils, shadowing the same-package fork class, so its unqualified call resolved upstream too. Its LogService import is repointed as well: the upstream interface is javax.servlet-bound via onInit(ServletContext).

No behaviour change; nothing reaches this code today.

fixes #1111 issue
